### PR TITLE
Use blocking spi traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changes
+- [breaking-change] Use SPI blocking traits instead to ease SPI peripheral sharing.
+  See: https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/28
+
+
+[Unreleased]: https://github.com/rust-embedded-community/embedded-sdmmc-rs/compare/v0.3.0...develop

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ nb = "0.1"
 log = "0.4"
 
 [dev-dependencies]
-env_logger = "0.7"
 hex-literal = "0.3"
+env_logger = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-embedded-hal = "^0.2.2"
+embedded-hal = "0.2.3"
 byteorder = { version = "1", default-features = false }
-nb = "0.1"
 log = "0.4"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,9 @@
 //! # struct DummyCsPin;
 //! # struct DummyUart;
 //! # struct DummyTimeSource;
-//! # impl embedded_hal::spi::FullDuplex<u8> for  DummySpi {
+//! # impl embedded_hal::blocking::spi::Transfer<u8> for  DummySpi {
 //! #   type Error = ();
-//! #   fn read(&mut self) -> nb::Result<u8, ()> { Ok(0) }
-//! #   fn send(&mut self, byte: u8) -> nb::Result<(), ()> { Ok(()) }
+//! #   fn transfer<'w>(&mut self, data: &'w mut [u8]) -> Result<&'w [u8], ()> { Ok(&[0]) }
 //! # }
 //! # impl embedded_hal::digital::v2::OutputPin for DummyCsPin {
 //! #   type Error = ();


### PR DESCRIPTION
- Shift to using blocking SPI traits for peripheral sharing ease
- Fix updating `embedded-hal` version to version 0.2.3 where the `digital::v2` traits were actually added.
- Update `env_logger` dependency
- Add Changelog

Thanks to @Rahix and @Maldus512
Fixes #28 