### PR TITLE
Let sdmmc::Error derive defmt::Format (if enabled)

### DIFF
--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -44,6 +44,7 @@ where
 
 /// The possible errors `SdMmcSpi` can generate.
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// We got an error from the SPI peripheral
     Transport,


### PR DESCRIPTION
This saves users from having to used `Debug2Format` and benefit from defmt for printing those errors too.