### PR TITLE
Customisable maximum number of open directories and files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]: https://github.com/rust-embedded-community/embedded-sdmmc-rs/compare/v0.4.0...develop
 
+### Changes
+- Add `MAX_DIRS` and `MAX_FILES` generics to `Controller` to allow an arbitrary numbers of concurrent open directories and files.
+
 ## [Version 0.4.0](https://github.com/rust-embedded-community/embedded-sdmmc-rs/releases/tag/v0.4.0)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -31,12 +31,28 @@ match spi_dev.acquire() {
 }
 ```
 
+### Open directories and files
+
+By default the `Controller` will initialize with a maximum number of `4` open directories and files. This can be customized by specifying the `MAX_DIR` and `MAX_FILES` generic consts of the `Controller`:
+
+```rust
+// Create a controller with a maximum of 6 open directories and 12 open files
+let mut cont: Controller<
+    embedded_sdmmc::BlockSpi<DummySpi, DummyCsPin>,
+    DummyTimeSource,
+    6,
+    12,
+> = Controller::new(block, time_source);
+```
+
 ## Supported features
 
 * Open files in all supported methods from an open directory
+* Open an arbitrary number of directories and files
 * Read data from open files
 * Write data to open files
 * Close files
+* Delete files
 * Iterate root directory
 * Iterate sub-directories
 * Log over defmt or the common log interface (feature flags).
@@ -44,7 +60,6 @@ match spi_dev.acquire() {
 ## Todo List (PRs welcome!)
 
 * Create new dirs
-* Delete files
 * Delete (empty) directories
 * Handle MS-DOS `/path/foo/bar.txt` style paths.
 

--- a/examples/create_test.rs
+++ b/examples/create_test.rs
@@ -118,7 +118,7 @@ fn main() {
         .map_err(Error::DeviceError)
         .unwrap();
     println!("lbd: {:?}", lbd);
-    let mut controller = Controller::new(lbd, Clock);
+    let mut controller: Controller<LinuxBlockDevice, Clock, 4, 4> = Controller::new(lbd, Clock);
     for volume_idx in 0..=3 {
         let volume = controller.get_volume(VolumeIdx(volume_idx));
         println!("volume {}: {:#?}", volume_idx, volume);

--- a/examples/delete_test.rs
+++ b/examples/delete_test.rs
@@ -118,7 +118,7 @@ fn main() {
         .map_err(Error::DeviceError)
         .unwrap();
     println!("lbd: {:?}", lbd);
-    let mut controller = Controller::new(lbd, Clock);
+    let mut controller: Controller<LinuxBlockDevice, Clock, 4, 4> = Controller::new(lbd, Clock);
     for volume_idx in 0..=3 {
         let volume = controller.get_volume(VolumeIdx(volume_idx));
         println!("volume {}: {:#?}", volume_idx, volume);

--- a/examples/test_mount.rs
+++ b/examples/test_mount.rs
@@ -121,7 +121,7 @@ fn main() {
         .map_err(Error::DeviceError)
         .unwrap();
     println!("lbd: {:?}", lbd);
-    let mut controller = Controller::new(lbd, Clock);
+    let mut controller: Controller<LinuxBlockDevice, Clock, 4, 4> = Controller::new(lbd, Clock);
     for i in 0..=3 {
         let volume = controller.get_volume(VolumeIdx(i));
         println!("volume {}: {:#?}", i, volume);

--- a/examples/write_test.rs
+++ b/examples/write_test.rs
@@ -118,7 +118,7 @@ fn main() {
         .map_err(Error::DeviceError)
         .unwrap();
     println!("lbd: {:?}", lbd);
-    let mut controller = Controller::new(lbd, Clock);
+    let mut controller: Controller<LinuxBlockDevice, Clock, 4, 4> = Controller::new(lbd, Clock);
     for volume_idx in 0..=3 {
         let volume = controller.get_volume(VolumeIdx(volume_idx));
         println!("volume {}: {:#?}", volume_idx, volume);

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -12,12 +12,12 @@ use crate::filesystem::{
     Attributes, Cluster, DirEntry, Directory, File, Mode, ShortFileName, TimeSource, MAX_FILE_SIZE,
 };
 use crate::{
-    Block, BlockCount, BlockDevice, BlockIdx, Error, Volume, VolumeIdx, VolumeType, MAX_OPEN_DIRS,
+    Block, BlockCount, BlockDevice, BlockIdx, Error, Volume, VolumeIdx, VolumeType,
     PARTITION_ID_FAT16, PARTITION_ID_FAT16_LBA, PARTITION_ID_FAT32_CHS_LBA, PARTITION_ID_FAT32_LBA,
 };
 
 /// A `Controller` wraps a block device and gives access to the volumes within it.
-pub struct Controller<D, T>
+pub struct Controller<D, T, const MAX_DIRS: usize = 4, const MAX_FILES: usize = 4>
 where
     D: BlockDevice,
     T: TimeSource,
@@ -25,11 +25,11 @@ where
 {
     pub(crate) block_device: D,
     pub(crate) timesource: T,
-    open_dirs: [(VolumeIdx, Cluster); MAX_OPEN_DIRS],
-    open_files: [(VolumeIdx, Cluster); MAX_OPEN_DIRS],
+    open_dirs: [(VolumeIdx, Cluster); MAX_DIRS],
+    open_files: [(VolumeIdx, Cluster); MAX_FILES],
 }
 
-impl<D, T> Controller<D, T>
+impl<D, T, const MAX_DIRS: usize, const MAX_FILES: usize> Controller<D, T, MAX_DIRS, MAX_FILES>
 where
     D: BlockDevice,
     T: TimeSource,
@@ -38,13 +38,13 @@ where
     /// Create a new Disk Controller using a generic `BlockDevice`. From this
     /// controller we can open volumes (partitions) and with those we can open
     /// files.
-    pub fn new(block_device: D, timesource: T) -> Controller<D, T> {
+    pub fn new(block_device: D, timesource: T) -> Controller<D, T, MAX_DIRS, MAX_FILES> {
         debug!("Creating new embedded-sdmmc::Controller");
         Controller {
             block_device,
             timesource,
-            open_dirs: [(VolumeIdx(0), Cluster::INVALID); 4],
-            open_files: [(VolumeIdx(0), Cluster::INVALID); 4],
+            open_dirs: [(VolumeIdx(0), Cluster::INVALID); MAX_DIRS],
+            open_files: [(VolumeIdx(0), Cluster::INVALID); MAX_FILES],
         }
     }
 

--- a/src/fat/volume.rs
+++ b/src/fat/volume.rs
@@ -68,9 +68,9 @@ pub struct FatVolume {
 
 impl FatVolume {
     /// Write a new entry in the FAT
-    pub fn update_info_sector<D, T>(
+    pub fn update_info_sector<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &mut self,
-        controller: &mut Controller<D, T>,
+        controller: &mut Controller<D, T, MAX_DIRS, MAX_FILES>,
     ) -> Result<(), Error<D::Error>>
     where
         D: BlockDevice,
@@ -112,9 +112,9 @@ impl FatVolume {
     }
 
     /// Write a new entry in the FAT
-    fn update_fat<D, T>(
+    fn update_fat<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &mut self,
-        controller: &mut Controller<D, T>,
+        controller: &mut Controller<D, T, MAX_DIRS, MAX_FILES>,
         cluster: Cluster,
         new_value: Cluster,
     ) -> Result<(), Error<D::Error>>
@@ -178,9 +178,9 @@ impl FatVolume {
     }
 
     /// Look in the FAT to see which cluster comes next.
-    pub(crate) fn next_cluster<D, T>(
+    pub(crate) fn next_cluster<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &self,
-        controller: &Controller<D, T>,
+        controller: &Controller<D, T, MAX_DIRS, MAX_FILES>,
         cluster: Cluster,
     ) -> Result<Cluster, Error<D::Error>>
     where
@@ -285,9 +285,9 @@ impl FatVolume {
 
     /// Finds a empty entry space and writes the new entry to it, allocates a new cluster if it's
     /// needed
-    pub(crate) fn write_new_directory_entry<D, T>(
+    pub(crate) fn write_new_directory_entry<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &mut self,
-        controller: &mut Controller<D, T>,
+        controller: &mut Controller<D, T, MAX_DIRS, MAX_FILES>,
         dir: &Directory,
         name: ShortFileName,
         attributes: Attributes,
@@ -422,9 +422,9 @@ impl FatVolume {
 
     /// Calls callback `func` with every valid entry in the given directory.
     /// Useful for performing directory listings.
-    pub(crate) fn iterate_dir<D, T, F>(
+    pub(crate) fn iterate_dir<D, T, F, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &self,
-        controller: &Controller<D, T>,
+        controller: &Controller<D, T, MAX_DIRS, MAX_FILES>,
         dir: &Directory,
         mut func: F,
     ) -> Result<(), Error<D::Error>>
@@ -522,9 +522,9 @@ impl FatVolume {
     }
 
     /// Get an entry from the given directory
-    pub(crate) fn find_directory_entry<D, T>(
+    pub(crate) fn find_directory_entry<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &self,
-        controller: &mut Controller<D, T>,
+        controller: &mut Controller<D, T, MAX_DIRS, MAX_FILES>,
         dir: &Directory,
         name: &str,
     ) -> Result<DirEntry, Error<D::Error>>
@@ -603,9 +603,9 @@ impl FatVolume {
     }
 
     /// Finds an entry in a given block
-    fn find_entry_in_block<D, T>(
+    fn find_entry_in_block<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &self,
-        controller: &mut Controller<D, T>,
+        controller: &mut Controller<D, T, MAX_FILES, MAX_DIRS>,
         fat_type: FatType,
         match_name: &ShortFileName,
         block: BlockIdx,
@@ -637,9 +637,9 @@ impl FatVolume {
     }
 
     /// Delete an entry from the given directory
-    pub(crate) fn delete_directory_entry<D, T>(
+    pub(crate) fn delete_directory_entry<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &self,
-        controller: &mut Controller<D, T>,
+        controller: &mut Controller<D, T, MAX_DIRS, MAX_FILES>,
         dir: &Directory,
         name: &str,
     ) -> Result<(), Error<D::Error>>
@@ -708,9 +708,9 @@ impl FatVolume {
     }
 
     /// Deletes an entry in a given block
-    fn delete_entry_in_block<D, T>(
+    fn delete_entry_in_block<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &self,
-        controller: &mut Controller<D, T>,
+        controller: &mut Controller<D, T, MAX_DIRS, MAX_FILES>,
         match_name: &ShortFileName,
         block: BlockIdx,
     ) -> Result<(), Error<D::Error>>
@@ -744,9 +744,9 @@ impl FatVolume {
     }
 
     /// Finds the next free cluster after the start_cluster and before end_cluster
-    pub(crate) fn find_next_free_cluster<D, T>(
+    pub(crate) fn find_next_free_cluster<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &self,
-        controller: &mut Controller<D, T>,
+        controller: &mut Controller<D, T, MAX_DIRS, MAX_FILES>,
         start_cluster: Cluster,
         end_cluster: Cluster,
     ) -> Result<Cluster, Error<D::Error>>
@@ -827,9 +827,9 @@ impl FatVolume {
     }
 
     /// Tries to allocate a cluster
-    pub(crate) fn alloc_cluster<D, T>(
+    pub(crate) fn alloc_cluster<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &mut self,
-        controller: &mut Controller<D, T>,
+        controller: &mut Controller<D, T, MAX_DIRS, MAX_FILES>,
         prev_cluster: Option<Cluster>,
         zero: bool,
     ) -> Result<Cluster, Error<D::Error>>
@@ -910,9 +910,9 @@ impl FatVolume {
     }
 
     /// Marks the input cluster as an EOF and all the subsequent clusters in the chain as free
-    pub(crate) fn truncate_cluster_chain<D, T>(
+    pub(crate) fn truncate_cluster_chain<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
         &mut self,
-        controller: &mut Controller<D, T>,
+        controller: &mut Controller<D, T, MAX_DIRS, MAX_FILES>,
         cluster: Cluster,
     ) -> Result<(), Error<D::Error>>
     where
@@ -958,8 +958,8 @@ impl FatVolume {
 
 /// Load the boot parameter block from the start of the given partition and
 /// determine if the partition contains a valid FAT16 or FAT32 file system.
-pub fn parse_volume<D, T>(
-    controller: &mut Controller<D, T>,
+pub fn parse_volume<D, T, const MAX_DIRS: usize, const MAX_FILES: usize>(
+    controller: &mut Controller<D, T, MAX_DIRS, MAX_FILES>,
     lba_start: BlockIdx,
     num_blocks: BlockCount,
 ) -> Result<VolumeType, Error<D::Error>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,14 +154,6 @@ where
     NotInBlock,
 }
 
-/// We have to track what directories are open to prevent users from modifying
-/// open directories (like creating a file when we have an open iterator).
-pub const MAX_OPEN_DIRS: usize = 4;
-
-/// We have to track what files and directories are open to prevent users from
-/// deleting open files (like Windows does).
-pub const MAX_OPEN_FILES: usize = 4;
-
 mod controller;
 pub use controller::Controller;
 
@@ -462,7 +454,8 @@ mod tests {
 
     #[test]
     fn partition0() {
-        let mut c = Controller::new(DummyBlockDevice, Clock);
+        let mut c: Controller<DummyBlockDevice, Clock, 4, 4> =
+            Controller::new(DummyBlockDevice, Clock);
         let v = c.get_volume(VolumeIdx(0)).unwrap();
         assert_eq!(
             v,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! # }
 //! # impl std::fmt::Write for DummyUart { fn write_str(&mut self, s: &str) -> std::fmt::Result { Ok(()) } }
 //! # use std::fmt::Write;
+//! # use embedded_sdmmc::Controller;
 //! # let mut uart = DummyUart;
 //! # let mut sdmmc_spi = DummySpi;
 //! # let mut sdmmc_cs = DummyCsPin;
@@ -44,7 +45,7 @@
 //!             DummyTimeSource,
 //!             4,
 //!             4,
-//!         > = embedded_sdmmc::Controller::new(block, time_source);
+//!         > = Controller::new(block, time_source);
 //!         write!(uart, "OK!\nCard size...").unwrap();
 //!         match cont.device().card_size_bytes() {
 //!             Ok(size) => writeln!(uart, "{}", size).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,12 @@
 //! write!(uart, "Init SD card...").unwrap();
 //! match spi_dev.acquire() {
 //!     Ok(block) => {
-//!         let mut cont = embedded_sdmmc::Controller::new(block, time_source);
+//!         let mut cont: Controller<
+//!             embedded_sdmmc::BlockSpi<DummySpi, DummyCsPin>,
+//!             DummyTimeSource,
+//!             4,
+//!             4,
+//!         > = embedded_sdmmc::Controller::new(block, time_source);
 //!         write!(uart, "OK!\nCard size...").unwrap();
 //!         match cont.device().card_size_bytes() {
 //!             Ok(size) => writeln!(uart, "{}", size).unwrap(),


### PR DESCRIPTION
Within my embedded app I require multiple data streams to multiple files, greater than the default supported amount which is currently `4`.

This PR simply allows customization of the maximum allowed open directories and files by replacing the hardcoded constants `MAX_OPEN_DIRS` and `MAX_OPEN_FILES` with const generics.

I've tested this change with stm32s and [this block device](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/src/sdmmc.rs#L1175) implementation and everything works and I currently have 9 files open simultaneously.

I'm curious to know why the default max was originally set at 4 directories and 4 files. Are there any potential ramifications for increasing these?

Any feedback or assistance with improving this is greatly appreciated.

Kind regards