### PR TITLE
Facilitate card initialization retries

### DIFF
--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -36,7 +36,7 @@ where
 /// An initialized block device used to access the SD card.
 /// **Caution**: any data must be flushed manually before dropping `BlockSpi`, see `deinit`.
 /// Uses SPI mode.
-pub struct BlockSpi<'a, SPI, CS>(&'a mut SdMmcSpi<SPI, CS>)
+pub struct BlockSpi<SPI, CS>(SdMmcSpi<SPI, CS>)
 where
     SPI: embedded_hal::blocking::spi::Transfer<u8>,
     CS: embedded_hal::digital::v2::OutputPin,
@@ -125,14 +125,14 @@ impl Delay {
 /// Options for acquiring the card.
 #[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy)]
-pub struct AcquireOpts {
+pub struct InitOpts {
     /// Some cards don't support CRC mode. At least a 512MiB Transcend one.
     pub require_crc: bool,
 }
 
-impl Default for AcquireOpts {
+impl Default for InitOpts {
     fn default() -> Self {
-        AcquireOpts { require_crc: true }
+        Self { require_crc: true }
     }
 }
 
@@ -168,7 +168,26 @@ where
         self.cs.borrow_mut().set_low().map_err(|_| Error::GpioError)
     }
 
-    fn acquire_with_opts_internal(&mut self, options: AcquireOpts) -> Result<(), Error> {
+    /// Initializes the card into a known state. Requires an [`InitToken`] which is used to statically check that the card has been intiialized before being used as a [`BlockSpi`].
+    pub fn acquire(self, _token: InitToken) -> BlockSpi<SPI, CS> {
+        BlockSpi(self)
+    }
+
+    /// Try to initialize the card into a known state. Returns a `Result<InitToken, Error>`. The  returned [`InitToken`]
+    /// can be used to acquire the card using [`acquire`](SdMmcSpi::acquire). This mehtod can be used in cases where you might want
+    /// to retry initializing the card more than once, and ensure that the lifetimes check out.
+    ///
+    /// To provide additional intialization options, use [`try_init_with_opts`](SdMmcSpi::try_init_with_opts).
+    pub fn try_init(&mut self) -> Result<InitToken, Error> {
+        self.try_init_with_opts(Default::default())
+    }
+
+    /// Try to initialize the card into a known state. Returns a `Result<InitToken, Error>`. The  returned [`InitToken`]
+    /// can be used to acquire the card using [`acquire`](SdMmcSpi::acquire). This mehtod can be used in cases where you might want
+    /// to retry initializing the card more than once, and ensure that the lifetimes check out.
+    ///
+    /// Provide additional intialization options with [`InitOpts`].
+    pub fn try_init_with_opts(&mut self, options: InitOpts) -> Result<InitToken, Error> {
         debug!("acquiring card with opts: {:?}", options);
         let f = |s: &mut Self| {
             // Assume it hasn't worked
@@ -259,37 +278,12 @@ where
             s.state = State::Idle;
             Ok(())
         };
-        let result = f(self);
+
+        f(self)?;
         self.cs_high()?;
+        // TODO should we check for Err here?
         let _ = self.receive();
-        result
-    }
-
-    /// Initializes the card into a known state
-    pub fn acquire(&mut self) -> Result<BlockSpi<'_, SPI, CS>, Error> {
-        self.acquire_with_opts(Default::default())
-    }
-
-    /// Initializes the card into a known state
-    pub fn acquire_with_opts(
-        &mut self,
-        options: AcquireOpts,
-    ) -> Result<BlockSpi<'_, SPI, CS>, Error> {
-        self.acquire_with_opts_internal(options)?;
-        Ok(BlockSpi(self))
-    }
-
-    /// Try to initialize the card into a known state. Returns a `Result<InitToken, Error>`. The [`InitToken`]
-    /// can be used to acquire the card using [`acquire_with_token`]. This mehtod can be used in cases where you might want
-    /// to retry initializing the card more than once, and ensure that the lifetimes check out.
-    pub fn try_init(&mut self, options: AcquireOpts) -> Result<InitToken, Error> {
-        self.acquire_with_opts_internal(options)?;
         Ok(InitToken { _private: () })
-    }
-
-    /// Acquire a card that has already been initialized through the [`try_init`] method.
-    pub fn acquire_with_token(&mut self, _token: InitToken) -> BlockSpi<'_, SPI, CS> {
-        BlockSpi(self)
     }
 
     /// Perform a function that might error with the chipselect low.
@@ -388,7 +382,7 @@ where
     }
 }
 
-impl<SPI, CS> BlockSpi<'_, SPI, CS>
+impl<SPI, CS> BlockSpi<SPI, CS>
 where
     SPI: embedded_hal::blocking::spi::Transfer<u8>,
     CS: embedded_hal::digital::v2::OutputPin,
@@ -398,6 +392,12 @@ where
     /// need to re-clock the SPI.
     pub fn spi(&mut self) -> core::cell::RefMut<SPI> {
         self.0.spi.borrow_mut()
+    }
+
+    /// Give ownership of the underlying [`SdMmcSpi`] back to the caller. Deinitializes the card first.
+    pub fn free(mut self) -> SdMmcSpi<SPI, CS> {
+        self.deinit();
+        self.0
     }
 
     /// Mark the card as unused.
@@ -507,7 +507,7 @@ where
     }
 }
 
-impl<SPI, CS> BlockDevice for BlockSpi<'_, SPI, CS>
+impl<SPI, CS> BlockDevice for BlockSpi<SPI, CS>
 where
     SPI: embedded_hal::blocking::spi::Transfer<u8>,
     <SPI as embedded_hal::blocking::spi::Transfer<u8>>::Error: core::fmt::Debug,
@@ -582,17 +582,6 @@ where
         let num_bytes = self.card_size_bytes()?;
         let num_blocks = (num_bytes / 512) as u32;
         Ok(BlockCount(num_blocks))
-    }
-}
-
-impl<SPI, CS> Drop for BlockSpi<'_, SPI, CS>
-where
-    SPI: embedded_hal::blocking::spi::Transfer<u8>,
-    <SPI as embedded_hal::blocking::spi::Transfer<u8>>::Error: core::fmt::Debug,
-    CS: embedded_hal::digital::v2::OutputPin,
-{
-    fn drop(&mut self) {
-        self.deinit()
     }
 }
 


### PR DESCRIPTION
Add `SdMmcSpi::try_init` and `SdMmcSpi::acquire_with_token` methods to facilitate retrying to initialize a card.

Consider the scenario where a card isn't plugged in when we try to initialize it, but we know it's going to be plugged in eventually. We would like to retry initializing until it succeeds. It's not possible using the current API:
``` rust
pub fn without_token<SPI, CS>(spi: &mut SdMmcSpi<SPI, CS>) -> BlockSpi<'_, SPI, CS>
where
    SPI: embedded_hal::blocking::spi::Transfer<u8>,
    CS: embedded_hal::digital::v2::OutputPin,
    <SPI as embedded_hal::blocking::spi::Transfer<u8>>::Error: core::fmt::Debug,
{
    let options = AcquireOpts::default();
    let mut maybe_block_spi = spi.acquire_with_opts(options);
    let block_spi = loop {
        match maybe_block_spi {
            Ok(t) => break t,
            Err(_) => maybe_block_spi = spi.acquire_with_opts(options),
        }
    };

    block_spi
}
```
fails to compile with this error:
```
21 | pub fn without_token<SPI, CS>(spi: &mut SdMmcSpi<SPI, CS>) -> BlockSpi<'_, SPI, CS>
   |                                    - let's call the lifetime of this reference `'1`
...
28 |     let mut maybe_block_spi = spi.acquire_with_opts(options);
   |                               ------------------------------ first mutable borrow occurs here
...
32 |             Err(_) => maybe_block_spi = spi.acquire_with_opts(options),
   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
...
36 |     block_spi
   |     --------- returning this value requires that `*spi` is borrowed for `'1`
```


This PR proposes adding an alternative intialization method, where we use `try_init` on an `SdMmcSpi`. Its lifetime is therefore not yet coupled to the `BlockSpi`'s, allowing us to retry initializing as many times as we want. In order to keep the typestate guarantees laid out by the current API, `try_init` will return an `InitToken` if the initialization succeeds. We can then call `SdMmcSpi::acquire_with_token` to convert it into a properly initialized `BlockSpi`. Consider this example, which compiles:
``` rust
pub fn with_token<SPI, CS>(spi: &mut SdMmcSpi<SPI, CS>) -> BlockSpi<'_, SPI, CS>
where
    SPI: embedded_hal::blocking::spi::Transfer<u8>,
    CS: embedded_hal::digital::v2::OutputPin,
    <SPI as embedded_hal::blocking::spi::Transfer<u8>>::Error: core::fmt::Debug,
{
    let options = AcquireOpts::default();
    let mut maybe_init = spi.try_init(options);
    loop {
        match maybe_init {
            Ok(t) => return spi.acquire_with_token(t),
            Err(_) => maybe_init = spi.try_init(options),
        }
    }
}
```