### PR TITLE
sdmmcspi: add method for borrowing spi (useful for re-clocking)

### DIFF
--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -360,6 +360,12 @@ where
         }
         Ok(())
     }
+
+    /// Get a temporary borrow on the underlying SPI device. Useful if you
+    /// need to re-clock the SPI.
+    pub fn spi(&mut self) -> core::cell::RefMut<SPI> {
+        self.spi.borrow_mut()
+    }
 }
 
 impl<SPI, CS> BlockSpi<'_, SPI, CS>


### PR DESCRIPTION
It is currently possible to re-clock the SPI after acquiring the
BlockSpi struct. However, if this fails later or needs to be re-done the
SPI bus should be clocked down to 100 - 400 kHz again. There is no way
to do this before acquiring without borrowing the spi device from
SdmmcSpi.
