### PR TITLE
Make `BlockSpi` take ownership of `SdMmcSpi`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,18 @@ designed for readability and simplicity over performance.
 You will need something that implements the `BlockDevice` trait, which can read and write the 512-byte blocks (or sectors) from your card. If you were to implement this over USB Mass Storage, there's no reason this crate couldn't work with a USB Thumb Drive, but we only supply a `BlockDevice` suitable for reading SD and SDHC cards over SPI.
 
 ```rust
-let mut spi_dev = embedded_sdmmc::SdMmcSpi::new(embedded_sdmmc::SdMmcSpi::new(sdmmc_spi, sdmmc_cs), time_source);
+let mut spi_dev = embedded_sdmmc::SdMmcSpi::new(sdmmc_spi, sdmmc_cs);
+let maybe_init = spi_dev.try_init();
 write!(uart, "Init SD card...").unwrap();
-match spi_dev.acquire() {
-    Ok(block) => {
-        let mut cont = embedded_sdmmc::Controller::new(block, time_source);
+match maybe_init {
+    Ok(token) => {
+        let block_spi = spi_dev.acquire(token);
+        let mut cont: Controller<
+            embedded_sdmmc::BlockSpi<DummySpi, DummyCsPin>,
+            DummyTimeSource,
+            4,
+            4,
+        > = Controller::new(block_spi, time_source);
         write!(uart, "OK!\nCard size...").unwrap();
         match cont.device().card_size_bytes() {
             Ok(size) => writeln!(uart, "{}", size).unwrap(),
@@ -28,7 +35,7 @@ match spi_dev.acquire() {
         }
     }
     Err(e) => writeln!(uart, "{:?}!", e).unwrap(),
-}
+};
 ```
 
 ### Open directories and files

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,15 +37,17 @@
 //! # let mut sdmmc_cs = DummyCsPin;
 //! # let time_source = DummyTimeSource;
 //! let mut spi_dev = embedded_sdmmc::SdMmcSpi::new(sdmmc_spi, sdmmc_cs);
+//! let maybe_init = spi_dev.try_init();
 //! write!(uart, "Init SD card...").unwrap();
-//! match spi_dev.acquire() {
-//!     Ok(block) => {
+//! match maybe_init {
+//!     Ok(token) => {
+//!         let block_spi = spi_dev.acquire(token);
 //!         let mut cont: Controller<
 //!             embedded_sdmmc::BlockSpi<DummySpi, DummyCsPin>,
 //!             DummyTimeSource,
 //!             4,
 //!             4,
-//!         > = Controller::new(block, time_source);
+//!         > = Controller::new(block_spi, time_source);
 //!         write!(uart, "OK!\nCard size...").unwrap();
 //!         match cont.device().card_size_bytes() {
 //!             Ok(size) => writeln!(uart, "{}", size).unwrap(),

--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -125,7 +125,7 @@ impl Delay {
 
 /// Options for acquiring the card.
 #[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct AcquireOpts {
     /// Some cards don't support CRC mode. At least a 512MiB Transcend one.
     pub require_crc: bool,
@@ -135,6 +135,11 @@ impl Default for AcquireOpts {
     fn default() -> Self {
         AcquireOpts { require_crc: true }
     }
+}
+
+/// Token indicating that the card is in a known good initialized state
+pub struct InitToken {
+    _private: (),
 }
 
 impl<SPI, CS> SdMmcSpi<SPI, CS>
@@ -164,13 +169,7 @@ where
         self.cs.borrow_mut().set_low().map_err(|_| Error::GpioError)
     }
 
-    /// Initializes the card into a known state
-    pub fn acquire(&mut self) -> Result<BlockSpi<SPI, CS>, Error> {
-        self.acquire_with_opts(Default::default())
-    }
-
-    /// Initializes the card into a known state
-    pub fn acquire_with_opts(&mut self, options: AcquireOpts) -> Result<BlockSpi<SPI, CS>, Error> {
+    fn acquire_with_opts_internal(&mut self, options: AcquireOpts) -> Result<(), Error> {
         debug!("acquiring card with opts: {:?}", options);
         let f = |s: &mut Self| {
             // Assume it hasn't worked
@@ -264,7 +263,34 @@ where
         let result = f(self);
         self.cs_high()?;
         let _ = self.receive();
-        result.map(move |()| BlockSpi(self))
+        result
+    }
+
+    /// Initializes the card into a known state
+    pub fn acquire(&mut self) -> Result<BlockSpi<'_, SPI, CS>, Error> {
+        self.acquire_with_opts(Default::default())
+    }
+
+    /// Initializes the card into a known state
+    pub fn acquire_with_opts(
+        &mut self,
+        options: AcquireOpts,
+    ) -> Result<BlockSpi<'_, SPI, CS>, Error> {
+        self.acquire_with_opts_internal(options)?;
+        Ok(BlockSpi(self))
+    }
+
+    /// Try to initialize the card into a known state. Returns a `Result<InitToken, Error>`. The [`InitToken`]
+    /// can be used to acquire the card using [`acquire_with_token`]. This mehtod can be used in cases where you might want
+    /// to retry initializing the card more than once, and ensure that the lifetimes check out.
+    pub fn try_init(&mut self, options: AcquireOpts) -> Result<InitToken, Error> {
+        self.acquire_with_opts_internal(options)?;
+        Ok(InitToken { _private: () })
+    }
+
+    /// Acquire a card that has already been initialized through the [`try_init`] method.
+    pub fn acquire_with_token(&mut self, _token: InitToken) -> BlockSpi<'_, SPI, CS> {
+        BlockSpi(self)
     }
 
     /// Perform a function that might error with the chipselect low.


### PR DESCRIPTION
The current `BlockSpi` API makes it quite difficult to pass ownership around because it borrows the underlying `SdMmcSpi`. This is especially unergonomic e.g. in RTIC, where a `Controller` could be initialized and is expected to be returned by the `init` function. See #56.

This PR proposes an alternative where `BlockSpi` takes ownership of the `SdMmcSpi`, while maintaining the typelevel guarantees that the card is properly initialized before a `BlockSpi` can be constructed.

This is achieved by using a `try_init` method on `SdMmcSpi`, which returns a `Result<InitToken, Error>`. This token can then be used in `acquire` to construct a `BlockSpi`. Since a succesful call to `try_init` and `try_init_with_opts` is the only (safe) way to acquire a `InitToken`, a `BlockSpi` is technically guaranteed to hold a correctly initialized card.

Initialization retries is also very easy using this API, because `try_init*` can be called repeatedly without having to reborrow the `SdMmcSpi`:

``` rust
pub fn init_retries<SPI, CS>(mut spi: SdMmcSpi<SPI, CS>) -> BlockSpi<SPI, CS>
where
    SPI: embedded_hal::blocking::spi::Transfer<u8>,
    CS: embedded_hal::digital::v2::OutputPin,
    <SPI as embedded_hal::blocking::spi::Transfer<u8>>::Error: core::fmt::Debug,
{
    let mut maybe_init = spi.try_init();
    loop {
        match maybe_init {
            Ok(t) => return spi.acquire(t),
            Err(_) => maybe_init = spi.try_init(),
        }
    }
}
```