### PR TITLE
Add the option to skip waiting in the init sequence when issuing CMD0.

### DIFF
--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -130,8 +130,8 @@ pub struct AcquireOpts {
     /// Some cards don't support CRC mode. At least a 512MiB Transcend one.
     pub require_crc: bool,
     /// Some cards should send CMD0 after an idle state to avoid being stuck in [`TimeoutWaitNotBusy`].
-    /// See [this conversation](https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33)
-    /// and [this one])(https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33).
+    /// See [this conversation](https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33#issue-803000031)
+    /// and [this one])(https://github.com/rust-embedded-community/embedded-sdmmc-rs/pull/32#issue-802999340).
     pub skip_wait_not_busy: bool,
 }
 
@@ -197,8 +197,8 @@ where
                 trace!("Enter SPI mode, attempt: {}..", 32i32 - attempts);
 
                 // Select whether or not to skip waiting for the card not to be busy
-                // when issuing the first CMD0. See https://github.com/rust-embedded-community/embedded-sdmmc-rs/pull/32 and
-                // https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33.
+                // when issuing the first CMD0. See https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33#issue-803000031 and
+                // https://github.com/rust-embedded-community/embedded-sdmmc-rs/pull/32#issue-802999340.
                 let cmd0_func = match options.skip_wait_not_busy {
                     true => Self::card_command_skip_wait,
                     false => Self::card_command,


### PR DESCRIPTION
Looking at #32 and #33, at least some cards get stuck in `TimeoutWaitNotBusy` when trying to initialize them. #32 provides a fix, however it seems to break other cards' init sequence.

I suggest adding an option in `AcquireOpts` to use this modified init sequence, with the default being to use the "regular" sequence.