### PR TITLE
Fix closing `File`s and `Directories`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.5.0"
 byteorder = {version = "1", default-features = false}
 defmt = {version = "0.3", optional = true}
 embedded-hal = "0.2.3"
+heapless = "0.7"
 log = {version = "0.4", default-features = false, optional = true}
 
 [dev-dependencies]

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -2,7 +2,7 @@ use core::convert::TryFrom;
 
 use crate::blockdevice::BlockIdx;
 use crate::fat::{FatType, OnDiskDirEntry};
-use crate::filesystem::{Attributes, Cluster, ShortFileName, Timestamp};
+use crate::filesystem::{Attributes, Cluster, SearchId, ShortFileName, Timestamp};
 
 /// Represents a directory entry, which tells you about
 /// other files and directories.
@@ -33,6 +33,8 @@ pub struct DirEntry {
 pub struct Directory {
     /// The starting point of the directory listing.
     pub(crate) cluster: Cluster,
+    /// Search ID for this directory.
+    pub(crate) search_id: SearchId,
 }
 
 impl DirEntry {

--- a/src/filesystem/files.rs
+++ b/src/filesystem/files.rs
@@ -1,4 +1,4 @@
-use crate::filesystem::{Cluster, DirEntry};
+use crate::filesystem::{Cluster, DirEntry, SearchId};
 
 /// Represents an open file on disk.
 #[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
@@ -16,6 +16,8 @@ pub struct File {
     pub(crate) mode: Mode,
     /// DirEntry of this file
     pub(crate) entry: DirEntry,
+    /// Search ID for this file
+    pub(crate) search_id: SearchId,
 }
 
 /// Errors related to file operations

--- a/src/filesystem/mod.rs
+++ b/src/filesystem/mod.rs
@@ -11,6 +11,7 @@ mod cluster;
 mod directory;
 mod filename;
 mod files;
+mod search_id;
 mod timestamp;
 
 pub use self::attributes::Attributes;
@@ -18,4 +19,5 @@ pub use self::cluster::Cluster;
 pub use self::directory::{DirEntry, Directory};
 pub use self::filename::{FilenameError, ShortFileName};
 pub use self::files::{File, FileError, Mode};
+pub use self::search_id::{IdGenerator, SearchId};
 pub use self::timestamp::{TimeSource, Timestamp};

--- a/src/filesystem/search_id.rs
+++ b/src/filesystem/search_id.rs
@@ -1,3 +1,5 @@
+use core::num::Wrapping;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
 /// Unique ID used to search for files and directories in the open File/Directory lists
@@ -7,19 +9,21 @@ pub struct SearchId(pub(crate) u32);
 ///
 /// This object will always return a different ID.
 pub struct IdGenerator {
-    next_id: u32,
+    next_id: Wrapping<u32>,
 }
 
 impl IdGenerator {
     /// Create a new [`IdGenerator`].
     pub const fn new() -> Self {
-        Self { next_id: 0 }
+        Self {
+            next_id: Wrapping(0),
+        }
     }
 
     /// Generate a new, unique [`SearchId`].
     pub fn get(&mut self) -> SearchId {
         let id = self.next_id;
-        self.next_id = self.next_id.wrapping_add(1);
-        SearchId(id)
+        self.next_id += 1;
+        SearchId(id.0)
     }
 }

--- a/src/filesystem/search_id.rs
+++ b/src/filesystem/search_id.rs
@@ -1,0 +1,34 @@
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
+/// Unique ID used to search for files and directories in the open File/Directory lists
+pub struct SearchId(pub(crate) u32);
+
+impl PartialEq for SearchId {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+/// ID generator intented to be used in a static context.
+///
+/// This object will always return a different ID.
+pub struct IdGenerator {
+    next_id: core::sync::atomic::AtomicU32,
+}
+
+impl IdGenerator {
+    /// Create a new [`IdGenerator`].
+    pub const fn new() -> Self {
+        Self {
+            next_id: core::sync::atomic::AtomicU32::new(0),
+        }
+    }
+
+    /// Generate a new, unique [`SearchId`].
+    pub fn next(&self) -> SearchId {
+        use core::sync::atomic::Ordering;
+        let id = self.next_id.load(Ordering::Acquire);
+        self.next_id.store(id + 1, Ordering::Release);
+        SearchId(id)
+    }
+}

--- a/src/filesystem/search_id.rs
+++ b/src/filesystem/search_id.rs
@@ -1,13 +1,7 @@
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
 /// Unique ID used to search for files and directories in the open File/Directory lists
 pub struct SearchId(pub(crate) u32);
-
-impl PartialEq for SearchId {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
 
 /// ID generator intented to be used in a static context.
 ///

--- a/src/filesystem/search_id.rs
+++ b/src/filesystem/search_id.rs
@@ -7,22 +7,19 @@ pub struct SearchId(pub(crate) u32);
 ///
 /// This object will always return a different ID.
 pub struct IdGenerator {
-    next_id: core::sync::atomic::AtomicU32,
+    next_id: u32,
 }
 
 impl IdGenerator {
     /// Create a new [`IdGenerator`].
     pub const fn new() -> Self {
-        Self {
-            next_id: core::sync::atomic::AtomicU32::new(0),
-        }
+        Self { next_id: 0 }
     }
 
     /// Generate a new, unique [`SearchId`].
-    pub fn next(&self) -> SearchId {
-        use core::sync::atomic::Ordering;
-        let id = self.next_id.load(Ordering::Acquire);
-        self.next_id.store(id + 1, Ordering::Release);
+    pub fn get(&mut self) -> SearchId {
+        let id = self.next_id;
+        self.next_id += 1;
         SearchId(id)
     }
 }

--- a/src/filesystem/search_id.rs
+++ b/src/filesystem/search_id.rs
@@ -19,7 +19,7 @@ impl IdGenerator {
     /// Generate a new, unique [`SearchId`].
     pub fn get(&mut self) -> SearchId {
         let id = self.next_id;
-        self.next_id += 1;
+        self.next_id = self.next_id.wrapping_add(1);
         SearchId(id)
     }
 }

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -264,7 +264,6 @@ where
         // with an ID which doesn't exist in our open dirs list.
         let idx_to_close = cluster_position_by_id(&self.open_dirs, dir.search_id).unwrap();
         self.open_dirs.remove(idx_to_close);
-        drop(dir);
     }
 
     /// Look in a directory for a named file.
@@ -664,7 +663,6 @@ where
         let idx_to_close = cluster_position_by_id(&self.open_files, file.search_id).unwrap();
         self.open_files.remove(idx_to_close);
 
-        drop(file);
         Ok(())
     }
 
@@ -733,8 +731,8 @@ where
     }
 }
 
-fn cluster_position_by_id(vec: &[ClusterDescriptor], id_to_find: SearchId) -> Option<usize> {
-    vec.iter().position(|f| f.compare_id(id_to_find))
+fn cluster_position_by_id(list: &[ClusterDescriptor], id_to_find: SearchId) -> Option<usize> {
+    list.iter().position(|f| f.compare_id(id_to_find))
 }
 
 fn cluster_already_open(

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -412,6 +412,12 @@ where
             _ => return Err(Error::FileNotFound),
         };
 
+        if let Some(d) = &dir_entry {
+            if cluster_already_open(&self.open_files, volume.idx, d.cluster) {
+                return Err(Error::FileAlreadyOpen);
+            }
+        }
+
         let mode = solve_mode_variant(mode, dir_entry.is_some());
 
         match mode {

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -406,7 +406,7 @@ where
                 open_files_row = Some(i);
             }
         }
-        open_files_row.ok_or(Error::TooManyOpenDirs)
+        open_files_row.ok_or(Error::TooManyOpenFiles)
     }
 
     /// Delete a closed file with the given full path, if exists.
@@ -498,6 +498,12 @@ where
             file.starting_cluster = match &mut volume.volume_type {
                 VolumeType::Fat(fat) => fat.alloc_cluster(self, None, false)?,
             };
+            for f in self.open_files.iter_mut() {
+                if f.1 == Cluster(0) {
+                    *f = (f.0, file.starting_cluster)
+                }
+            }
+
             file.entry.cluster = file.starting_cluster;
             debug!("Alloc first cluster {:?}", file.starting_cluster);
         }

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -737,16 +737,20 @@ where
     }
 }
 
-fn cluster_position_by_id(list: &[ClusterDescriptor], id_to_find: SearchId) -> Option<usize> {
-    list.iter().position(|f| f.compare_id(id_to_find))
+fn cluster_position_by_id(
+    cluster_list: &[ClusterDescriptor],
+    id_to_find: SearchId,
+) -> Option<usize> {
+    cluster_list.iter().position(|f| f.compare_id(id_to_find))
 }
 
 fn cluster_already_open(
-    vec: &[ClusterDescriptor],
+    cluster_list: &[ClusterDescriptor],
     volume_idx: VolumeIdx,
     cluster: Cluster,
 ) -> bool {
-    vec.iter()
+    cluster_list
+        .iter()
         .any(|d| d.compare_volume_and_cluster(volume_idx, cluster))
 }
 


### PR DESCRIPTION
This PR attempts to fix closing `Files` and `Directories`.

The working principle is that each new `File` and `Directory` is assigned a unique `SearchId`. To close/delete them, instead of looking for magic `Cluster` numbers, we simply need to lookup the ID in the list of open files or directories. This mitigates the issues where we might forget to update the cluster number, or where there might be multiple cluster numbers with the same value (most notably, 0).

Also replace raw arrays with `heapless::Vec`s for a cleaner implementation.

Optionally, this could remove the need for a `&Volume` parameter in the `close_dir` and `close_file` methods.

@ostenning and @thejpster, I would very much like to know what you think of this. I'm not super familiar with the internals of this library so I'd definitely like a good review.

Hopefully fixes #66.