### PR TITLE
Skip wait init sequence

### DIFF
--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -129,18 +129,11 @@ impl Delay {
 pub struct AcquireOpts {
     /// Some cards don't support CRC mode. At least a 512MiB Transcend one.
     pub require_crc: bool,
-    /// Some cards should send CMD0 after an idle state to avoid being stuck in [`TimeoutWaitNotBusy`].
-    /// See [this conversation](https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33#issue-803000031)
-    /// and [this one])(https://github.com/rust-embedded-community/embedded-sdmmc-rs/pull/32#issue-802999340).
-    pub skip_wait_not_busy: bool,
 }
 
 impl Default for AcquireOpts {
     fn default() -> Self {
-        AcquireOpts {
-            require_crc: true,
-            skip_wait_not_busy: false,
-        }
+        AcquireOpts { require_crc: true }
     }
 }
 
@@ -311,7 +304,9 @@ where
 
     /// Perform a command.
     fn card_command(&self, command: u8, arg: u32) -> Result<u8, Error> {
-        self.wait_not_busy()?;
+        if command != CMD0 && command != CMD12 {
+            self.wait_not_busy()?;
+        }
 
         let mut buf = [
             0x40 | command,

--- a/src/sdmmc.rs
+++ b/src/sdmmc.rs
@@ -130,8 +130,8 @@ pub struct AcquireOpts {
     /// Some cards don't support CRC mode. At least a 512MiB Transcend one.
     pub require_crc: bool,
     /// Some cards should send CMD0 after an idle state to avoid being stuck in [`TimeoutWaitNotBusy`].
-    /// See [this conversation](https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33)
-    /// and [this one])(https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33).
+    /// See [this conversation](https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33#issue-803000031)
+    /// and [this one])(https://github.com/rust-embedded-community/embedded-sdmmc-rs/pull/32#issue-802999340).
     pub skip_wait_not_busy: bool,
 }
 
@@ -197,8 +197,8 @@ where
                 trace!("Enter SPI mode, attempt: {}..", 32i32 - attempts);
 
                 // Select whether or not to skip waiting for the card not to be busy
-                // when issuing the first CMD0. See https://github.com/rust-embedded-community/embedded-sdmmc-rs/pull/32 and
-                // https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33.
+                // when issuing the first CMD0. See https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33#issue-803000031 and
+                // https://github.com/rust-embedded-community/embedded-sdmmc-rs/pull/32#issue-802999340.
                 let cmd0_func = match options.skip_wait_not_busy {
                     true => Self::card_command_skip_wait,
                     false => Self::card_command,


### PR DESCRIPTION
As discussed in issue #33, I've tested this with a brand new card from SanDisk (64GB) and so far it's working.

As mentioned in comment https://github.com/rust-embedded-community/embedded-sdmmc-rs/issues/33#issuecomment-1407425962, there are a few responses that are returned first (probably responses for proprietary functionality) and after the initial 2 responses, it acquires the device successfully.

```
0.001253 WARN  Got response: 3f, trying again..
└─ embedded_sdmmc::sdmmc::{impl#2}::acquire_with_opts::{closure#0} @ /mnt/Disk/Projects/lechev.space/embedded-sdmmc-rs/src/sdmmc.rs:211
0.001429 WARN  Got response: 7f, trying again..
└─ embedded_sdmmc::sdmmc::{impl#2}::acquire_with_opts::{closure#0} @ /mnt/Disk/Projects/lechev.space/embedded-sdmmc-rs/src/sdmmc.rs:211
```