### PR TITLE
Removed unused field.

### DIFF
--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -33,8 +33,6 @@ pub struct DirEntry {
 pub struct Directory {
     /// The starting point of the directory listing.
     pub(crate) cluster: Cluster,
-    /// Dir Entry of this directory, None for the root directory
-    pub(crate) entry: Option<DirEntry>,
 }
 
 impl DirEntry {

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -172,7 +172,6 @@ where
         self.open_dirs[open_dirs_row] = (volume.idx, Cluster::ROOT_DIR);
         Ok(Directory {
             cluster: Cluster::ROOT_DIR,
-            entry: None,
         })
     }
 
@@ -217,7 +216,6 @@ where
         self.open_dirs[open_dirs_row] = (volume.idx, dir_entry.cluster);
         Ok(Directory {
             cluster: dir_entry.cluster,
-            entry: Some(dir_entry),
         })
     }
 


### PR DESCRIPTION
It was a rustc warning and it seems to work without. If we need it in future, we can add it back.