### PR TITLE
User-selectable number of retries for card acquisition

### DIFF
--- a/src/sdcard/mod.rs
+++ b/src/sdcard/mod.rs
@@ -715,13 +715,12 @@ impl Delay {
         T: embedded_hal::blocking::delay::DelayUs<u8>,
     {
         if self.retries_left == 0 {
-            return Err(err);
+            Err(err)
         } else {
             delayer.delay_us(10);
             self.retries_left -= 1;
+            Ok(())
         }
-
-        Ok(())
     }
 }
 

--- a/src/sdcard/mod.rs
+++ b/src/sdcard/mod.rs
@@ -401,7 +401,7 @@ where
             // Assert CS
             s.cs_low()?;
             // Enter SPI mode.
-            let mut delay = Delay::new_command();
+            let mut delay = Delay::new(s.options.acquire_retries);
             for attempts in 1.. {
                 trace!("Enter SPI mode, attempt: {}..", attempts);
                 match s.card_command(CMD0, 0) {
@@ -586,11 +586,18 @@ pub struct AcquireOpts {
     /// On by default because without it you might get silent data corruption on
     /// your card.
     pub use_crc: bool,
+
+    /// Sets the number of times we will retry to acquire the card before giving up and returning
+    /// `Err(Error::CardNotFound)`. By default, card acquisition will be retried 50 times.
+    pub acquire_retries: u32,
 }
 
 impl Default for AcquireOpts {
     fn default() -> Self {
-        AcquireOpts { use_crc: true }
+        AcquireOpts {
+            use_crc: true,
+            acquire_retries: 50,
+        }
     }
 }
 
@@ -708,12 +715,13 @@ impl Delay {
         T: embedded_hal::blocking::delay::DelayUs<u8>,
     {
         if self.retries_left == 0 {
-            Err(err)
+            return Err(err);
         } else {
             delayer.delay_us(10);
             self.retries_left -= 1;
-            Ok(())
         }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Provides a way for the user to specify how many times acquiring the card should be retried before giving up and returning `Error::CardNotFound`. This is done by way of a field in `AcquireOpts`.

Closes #88.