### PR TITLE
Add a local on-stack FAT cache for next_cluster

### DIFF
--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -3,7 +3,8 @@
 use byteorder::{ByteOrder, LittleEndian};
 use core::convert::TryFrom;
 
-use crate::fat::{self, RESERVED_ENTRIES};
+use crate::fat::{self, BlockCache, RESERVED_ENTRIES};
+
 use crate::filesystem::{
     Attributes, Cluster, DirEntry, Directory, File, IdGenerator, Mode, SearchId, ShortFileName,
     TimeSource, MAX_FILE_SIZE,
@@ -697,9 +698,10 @@ where
         // How many clusters forward do we need to go?
         let offset_from_cluster = desired_offset - start.0;
         let num_clusters = offset_from_cluster / bytes_per_cluster;
+        let mut block_cache = BlockCache::empty();
         for _ in 0..num_clusters {
             start.1 = match &volume.volume_type {
-                VolumeType::Fat(fat) => fat.next_cluster(self, start.1)?,
+                VolumeType::Fat(fat) => fat.next_cluster(self, start.1, &mut block_cache)?,
             };
             start.0 += bytes_per_cluster;
         }


### PR DESCRIPTION
For some operations, e.g. seeking in a file, this makes a huge performance difference since we avoid (re)reading the FAT for every node in the linked list.
For other operations that call next_cluster only once there are no negative implications since the memory for the FAT block would have been allocated on the stack anyways.

A motivation from my specific use case: Seeking in a somewhat large audio file (e.g. 30 minutes) would take multiple seconds, but is now without any perceptible delay.