### PR TITLE
fix: on multi-block writes send ACMD23 and wait not busy

### DIFF
--- a/src/sdcard/mod.rs
+++ b/src/sdcard/mod.rs
@@ -237,6 +237,13 @@ where
                     return Err(Error::WriteError);
                 }
             } else {
+                // > It is recommended using this command preceding CMD25, some of the cards will be faster for Multiple
+                // > Write Blocks operation. Note that the host should send ACMD23 just before WRITE command if the host
+                // > wants to use the pre-erased feature
+                s.card_acmd(ACMD23, blocks.len() as u32)?;
+                // wait for card to be ready before sending the next command
+                s.wait_not_busy(Delay::new_write())?;
+
                 // Start a multi-block write
                 s.card_command(CMD25, start_idx)?;
                 for block in blocks.iter() {

--- a/src/sdcard/proto.rs
+++ b/src/sdcard/proto.rs
@@ -60,6 +60,12 @@ pub const CMD55: u8 = 0x37;
 pub const CMD58: u8 = 0x3A;
 /// CRC_ON_OFF - enable or disable CRC checking
 pub const CMD59: u8 = 0x3B;
+/// Pre-erased before writing
+///
+/// > It is recommended using this command preceding CMD25, some of the cards will be faster for Multiple
+/// > Write Blocks operation. Note that the host should send ACMD23 just before WRITE command if the host
+/// > wants to use the pre-erased feature
+pub const ACMD23: u8 = 0x17;
 /// SD_SEND_OP_COMD - Sends host capacity support information and activates
 /// the card's initialization process
 pub const ACMD41: u8 = 0x29;


### PR DESCRIPTION
- Wait not busy fixes multiblock writes at least for the SD card I was using (SanDisk extreme 32 GB) otherwise I was getting a Timeout
- Sending ACMD23 can considerably improve writing speeds for some cards which pre-erase the blocks.