### PR TITLE
Smart Handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 
 ## [Unreleased]
 
-* None
+* `Volume`, `Directory` and `File` are now smart! They hold references to the thing they were made from, and will clean themselves up when dropped. The trade-off is you can can't open multiple volumes, directories or files at the same time.
+* Renamed the old types to `RawVolume`, `RawDirectory` and `RawFile`
 
 ## [Version 0.6.0] - 2023-10-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ log = {version = "0.4", default-features = false, optional = true}
 env_logger = "0.9"
 hex-literal = "0.3"
 flate2 = "1.0"
-sha256 = "1.4"
+sha2 = "0.10"
 chrono = "0.4"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ chrono = "0.4"
 
 [features]
 default = ["log"]
-defmt-log = ["defmt"]
+defmt-log = ["dep:defmt"]
+log = ["dep:log"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ designed for readability and simplicity over performance.
 You will need something that implements the `BlockDevice` trait, which can read and write the 512-byte blocks (or sectors) from your card. If you were to implement this over USB Mass Storage, there's no reason this crate couldn't work with a USB Thumb Drive, but we only supply a `BlockDevice` suitable for reading SD and SDHC cards over SPI.
 
 ```rust
-// Build an SD Card interface out of an SPI device, a chip-select pin and a delay object
+// Build an SD Card interface out of an SPI device, a chip-select pin and the delay object
 let sdcard = embedded_sdmmc::SdCard::new(sdmmc_spi, sdmmc_cs, delay);
 // Get the card size (this also triggers card initialisation because it's not been done yet)
 println!("Card size is {} bytes", sdcard.num_bytes()?);
@@ -20,29 +20,21 @@ println!("Card size is {} bytes", sdcard.num_bytes()?);
 let mut volume_mgr = embedded_sdmmc::VolumeManager::new(sdcard, time_source);
 // Try and access Volume 0 (i.e. the first partition).
 // The volume object holds information about the filesystem on that volume.
-// It doesn't hold a reference to the Volume Manager and so must be passed back
-// to every Volume Manager API call. This makes it easier to handle multiple
-// volumes in parallel.
-let volume0 = volume_mgr.get_volume(embedded_sdmmc::VolumeIdx(0))?;
+let mut volume0 = volume_mgr.open_volume(embedded_sdmmc::VolumeIdx(0))?;
 println!("Volume 0: {:?}", volume0);
-// Open the root directory (passing in the volume we're using).
-let root_dir = volume_mgr.open_root_dir(&volume0)?;
+// Open the root directory (mutably borrows from the volume).
+let mut root_dir = volume0.open_root_dir()?;
 // Open a file called "MY_FILE.TXT" in the root directory
-let my_file = volume_mgr.open_file_in_dir(
-    root_dir,
-    "MY_FILE.TXT",
-    embedded_sdmmc::Mode::ReadOnly,
-)?;
+// This mutably borrows the directory.
+let mut my_file = root_dir.open_file_in_dir("MY_FILE.TXT", embedded_sdmmc::Mode::ReadOnly)?;
 // Print the contents of the file
-while !volume_manager.file_eof(my_file).unwrap() {
+while !my_file.is_eof() {
     let mut buffer = [0u8; 32];
-    let num_read = volume_mgr.read(&volume0, &mut my_file, &mut buffer)?;
+    let num_read = my_file.read(&mut buffer)?;
     for b in &buffer[0..num_read] {
         print!("{}", *b as char);
     }
 }
-volume_mgr.close_file(my_file)?;
-volume_mgr.close_dir(root_dir)?;
 ```
 
 ### Open directories and files

--- a/examples/append_file.rs
+++ b/examples/append_file.rs
@@ -32,13 +32,11 @@ fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
     let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let volume = volume_mgr.open_volume(VolumeIdx(0))?;
-    let root_dir = volume_mgr.open_root_dir(volume)?;
+    let mut volume = volume_mgr.open_volume(VolumeIdx(0))?;
+    let mut root_dir = volume.open_root_dir()?;
     println!("\nCreating file {}...", FILE_TO_APPEND);
-    let f = volume_mgr.open_file_in_dir(root_dir, FILE_TO_APPEND, Mode::ReadWriteAppend)?;
-    volume_mgr.write(f, b"\r\n\r\nThis has been added to your file.\r\n")?;
-    volume_mgr.close_file(f)?;
-    volume_mgr.close_dir(root_dir)?;
+    let mut f = root_dir.open_file_in_dir(FILE_TO_APPEND, Mode::ReadWriteAppend)?;
+    f.write(b"\r\n\r\nThis has been added to your file.\r\n")?;
     Ok(())
 }
 

--- a/examples/create_file.rs
+++ b/examples/create_file.rs
@@ -32,16 +32,14 @@ fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
     let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let volume = volume_mgr.open_volume(VolumeIdx(0))?;
-    let root_dir = volume_mgr.open_root_dir(volume)?;
+    let mut volume = volume_mgr.open_volume(VolumeIdx(0))?;
+    let mut root_dir = volume.open_root_dir()?;
     println!("\nCreating file {}...", FILE_TO_CREATE);
     // This will panic if the file already exists: use ReadWriteCreateOrAppend
     // or ReadWriteCreateOrTruncate instead if you want to modify an existing
     // file.
-    let f = volume_mgr.open_file_in_dir(root_dir, FILE_TO_CREATE, Mode::ReadWriteCreate)?;
-    volume_mgr.write(f, b"Hello, this is a new file on disk\r\n")?;
-    volume_mgr.close_file(f)?;
-    volume_mgr.close_dir(root_dir)?;
+    let mut f = root_dir.open_file_in_dir(FILE_TO_CREATE, Mode::ReadWriteCreate)?;
+    f.write(b"Hello, this is a new file on disk\r\n")?;
     Ok(())
 }
 

--- a/examples/delete_file.rs
+++ b/examples/delete_file.rs
@@ -35,12 +35,11 @@ fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
     let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let volume = volume_mgr.open_volume(VolumeIdx(0))?;
-    let root_dir = volume_mgr.open_root_dir(volume)?;
+    let mut volume = volume_mgr.open_volume(VolumeIdx(0))?;
+    let mut root_dir = volume.open_root_dir()?;
     println!("Deleting file {}...", FILE_TO_DELETE);
-    volume_mgr.delete_file_in_dir(root_dir, FILE_TO_DELETE)?;
+    root_dir.delete_file_in_dir(FILE_TO_DELETE)?;
     println!("Deleted!");
-    volume_mgr.close_dir(root_dir)?;
     Ok(())
 }
 

--- a/examples/list_dir.rs
+++ b/examples/list_dir.rs
@@ -49,10 +49,9 @@ fn main() -> Result<(), Error> {
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
     let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let volume = volume_mgr.open_volume(VolumeIdx(0))?;
-    let root_dir = volume_mgr.open_root_dir(volume)?;
-    list_dir(&mut volume_mgr, root_dir, "/")?;
-    volume_mgr.close_dir(root_dir)?;
+    let mut volume = volume_mgr.open_volume(VolumeIdx(0))?;
+    let root_dir = volume.open_root_dir()?;
+    list_dir(root_dir, "/")?;
     Ok(())
 }
 
@@ -60,13 +59,12 @@ fn main() -> Result<(), Error> {
 ///
 /// The path is for display purposes only.
 fn list_dir(
-    volume_mgr: &mut VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4>,
-    directory: Directory,
+    mut directory: Directory<LinuxBlockDevice, Clock, 8, 8, 4>,
     path: &str,
 ) -> Result<(), Error> {
     println!("Listing {}", path);
     let mut children = Vec::new();
-    volume_mgr.iterate_dir(directory, |entry| {
+    directory.iterate_dir(|entry| {
         println!(
             "{:12} {:9} {} {}",
             entry.name,
@@ -87,14 +85,13 @@ fn list_dir(
         }
     })?;
     for child_name in children {
-        let child_dir = volume_mgr.open_dir(directory, &child_name)?;
+        let child_dir = directory.open_dir(&child_name)?;
         let child_path = if path == "/" {
             format!("/{}", child_name)
         } else {
             format!("{}/{}", path, child_name)
         };
-        list_dir(volume_mgr, child_dir, &child_path)?;
-        volume_mgr.close_dir(child_dir)?;
+        list_dir(child_dir, &child_path)?;
     }
     Ok(())
 }

--- a/examples/read_file.rs
+++ b/examples/read_file.rs
@@ -49,15 +49,14 @@ fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
     let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let volume = volume_mgr.open_volume(VolumeIdx(0))?;
-    let root_dir = volume_mgr.open_root_dir(volume)?;
+    let mut volume = volume_mgr.open_volume(VolumeIdx(0))?;
+    let mut root_dir = volume.open_root_dir()?;
     println!("\nReading file {}...", FILE_TO_READ);
-    let f = volume_mgr.open_file_in_dir(root_dir, FILE_TO_READ, Mode::ReadOnly)?;
-    volume_mgr.close_dir(root_dir)?;
-    while !volume_mgr.file_eof(f)? {
+    let mut f = root_dir.open_file_in_dir(FILE_TO_READ, Mode::ReadOnly)?;
+    while !f.is_eof() {
         let mut buffer = [0u8; 16];
-        let offset = volume_mgr.file_offset(f)?;
-        let mut len = volume_mgr.read(f, &mut buffer)?;
+        let offset = f.offset();
+        let mut len = f.read(&mut buffer)?;
         print!("{:08x} {:02x?}", offset, &buffer[0..len]);
         while len < buffer.len() {
             print!("    ");
@@ -74,7 +73,6 @@ fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
         }
         println!("|");
     }
-    volume_mgr.close_file(f)?;
     Ok(())
 }
 

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -75,7 +75,6 @@ impl RawDirectory {
 /// If you drop a value of this type, it closes the directory automatically. However,
 /// it holds a mutable reference to its parent `VolumeManager`, which restricts
 /// which operations you can perform.
-#[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
 pub struct Directory<
     'a,
     D,
@@ -191,6 +190,18 @@ where
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Directory({})", self.raw_directory.0 .0)
+    }
+}
+
+#[cfg(feature = "defmt-log")]
+impl<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
+    defmt::Format for Directory<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+where
+    D: crate::BlockDevice,
+    T: crate::TimeSource,
+{
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "Directory({})", self.raw_directory.0 .0)
     }
 }
 

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -3,7 +3,9 @@ use core::convert::TryFrom;
 use crate::blockdevice::BlockIdx;
 use crate::fat::{FatType, OnDiskDirEntry};
 use crate::filesystem::{Attributes, ClusterId, SearchId, ShortFileName, Timestamp};
-use crate::Volume;
+use crate::{Error, RawVolume, VolumeManager};
+
+use super::ToShortFileName;
 
 /// Represents a directory entry, which tells you about
 /// other files and directories.
@@ -46,16 +48,160 @@ pub struct DirEntry {
 /// and there's a reason we did it this way.
 #[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct Directory(pub(crate) SearchId);
+pub struct RawDirectory(pub(crate) SearchId);
+
+impl RawDirectory {
+    /// Convert a raw file into a droppable [`File`]
+    pub fn to_directory<
+        D,
+        T,
+        const MAX_DIRS: usize,
+        const MAX_FILES: usize,
+        const MAX_VOLUMES: usize,
+    >(
+        self,
+        volume_mgr: &mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+    ) -> Directory<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+    where
+        D: crate::BlockDevice,
+        T: crate::TimeSource,
+    {
+        Directory::new(self, volume_mgr)
+    }
+}
+
+/// Represents an open directory on disk.
+///
+/// If you drop a value of this type, it closes the directory automatically. However,
+/// it holds a mutable reference to its parent `VolumeManager`, which restricts
+/// which operations you can perform.
+#[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
+pub struct Directory<
+    'a,
+    D,
+    T,
+    const MAX_DIRS: usize,
+    const MAX_FILES: usize,
+    const MAX_VOLUMES: usize,
+> where
+    D: crate::BlockDevice,
+    T: crate::TimeSource,
+{
+    raw_directory: RawDirectory,
+    volume_mgr: &'a mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+}
+
+impl<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
+    Directory<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+where
+    D: crate::BlockDevice,
+    T: crate::TimeSource,
+{
+    /// Create a new `Directory` from a `RawDirectory`
+    pub fn new(
+        raw_directory: RawDirectory,
+        volume_mgr: &'a mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+    ) -> Directory<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES> {
+        Directory {
+            raw_directory,
+            volume_mgr,
+        }
+    }
+
+    /// Open a directory.
+    ///
+    /// You can then read the directory entries with `iterate_dir` and `open_file_in_dir`.
+    pub fn open_dir<N>(
+        &mut self,
+        name: N,
+    ) -> Result<Directory<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>>
+    where
+        N: ToShortFileName,
+    {
+        let d = self.volume_mgr.open_dir(self.raw_directory, name)?;
+        Ok(d.to_directory(self.volume_mgr))
+    }
+
+    /// Look in a directory for a named file.
+    pub fn find_directory_entry<N>(&mut self, name: N) -> Result<DirEntry, Error<D::Error>>
+    where
+        N: ToShortFileName,
+    {
+        self.volume_mgr
+            .find_directory_entry(self.raw_directory, name)
+    }
+
+    /// Call a callback function for each directory entry in a directory.
+    pub fn iterate_dir<F>(&mut self, func: F) -> Result<(), Error<D::Error>>
+    where
+        F: FnMut(&DirEntry),
+    {
+        self.volume_mgr.iterate_dir(self.raw_directory, func)
+    }
+
+    /// Open a file with the given full path. A file can only be opened once.
+    pub fn open_file_in_dir<N>(
+        &mut self,
+        name: N,
+        mode: crate::Mode,
+    ) -> Result<crate::File<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, crate::Error<D::Error>>
+    where
+        N: super::ToShortFileName,
+    {
+        let f = self
+            .volume_mgr
+            .open_file_in_dir(self.raw_directory, name, mode)?;
+        Ok(f.to_file(self.volume_mgr))
+    }
+
+    /// Delete a closed file with the given filename, if it exists.
+    pub fn delete_file_in_dir<N>(&mut self, name: N) -> Result<(), Error<D::Error>>
+    where
+        N: ToShortFileName,
+    {
+        self.volume_mgr.delete_file_in_dir(self.raw_directory, name)
+    }
+
+    /// Convert back to a raw directory
+    pub fn to_raw_directory(self) -> RawDirectory {
+        let d = self.raw_directory;
+        core::mem::forget(self);
+        d
+    }
+}
+
+impl<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize> Drop
+    for Directory<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+where
+    D: crate::BlockDevice,
+    T: crate::TimeSource,
+{
+    fn drop(&mut self) {
+        self.volume_mgr
+            .close_dir(self.raw_directory)
+            .expect("Failed to close directory");
+    }
+}
+
+impl<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
+    core::fmt::Debug for Directory<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+where
+    D: crate::BlockDevice,
+    T: crate::TimeSource,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Directory({})", self.raw_directory.0 .0)
+    }
+}
 
 /// Holds information about an open file on disk
 #[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
 #[derive(Debug, Clone)]
 pub(crate) struct DirectoryInfo {
     /// Unique ID for this directory.
-    pub(crate) directory_id: Directory,
+    pub(crate) directory_id: RawDirectory,
     /// The unique ID for the volume this directory is on
-    pub(crate) volume_id: Volume,
+    pub(crate) volume_id: RawVolume,
     /// The starting point of the directory listing.
     pub(crate) cluster: ClusterId,
 }

--- a/src/filesystem/files.rs
+++ b/src/filesystem/files.rs
@@ -42,7 +42,6 @@ impl RawFile {
 /// If you drop a value of this type, it closes the file automatically. However,
 /// it holds a mutable reference to its parent `VolumeManager`, which restricts
 /// which operations you can perform.
-#[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
 pub struct File<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
 where
     D: crate::BlockDevice,
@@ -147,6 +146,18 @@ where
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "File({})", self.raw_file.0 .0)
+    }
+}
+
+#[cfg(feature = "defmt-log")]
+impl<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
+    defmt::Format for File<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+where
+    D: crate::BlockDevice,
+    T: crate::TimeSource,
+{
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "File({})", self.raw_file.0 .0)
     }
 }
 

--- a/src/filesystem/mod.rs
+++ b/src/filesystem/mod.rs
@@ -16,9 +16,9 @@ mod timestamp;
 
 pub use self::attributes::Attributes;
 pub use self::cluster::ClusterId;
-pub use self::directory::{DirEntry, Directory};
+pub use self::directory::{DirEntry, Directory, RawDirectory};
 pub use self::filename::{FilenameError, ShortFileName, ToShortFileName};
-pub use self::files::{File, FileError, Mode};
+pub use self::files::{File, FileError, Mode, RawFile};
 pub use self::search_id::{SearchId, SearchIdGenerator};
 pub use self::timestamp::{TimeSource, Timestamp};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,6 @@ impl RawVolume {
 /// If you drop a value of this type, it closes the volume automatically. However,
 /// it holds a mutable reference to its parent `VolumeManager`, which restricts
 /// which operations you can perform.
-#[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
 pub struct Volume<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
 where
     D: crate::BlockDevice,
@@ -330,6 +329,18 @@ where
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Volume({})", self.raw_volume.0 .0)
+    }
+}
+
+#[cfg(feature = "defmt-log")]
+impl<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
+    defmt::Format for Volume<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+where
+    D: crate::BlockDevice,
+    T: crate::TimeSource,
+{
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "Volume({})", self.raw_volume.0 .0)
     }
 }
 

--- a/tests/open_files.rs
+++ b/tests/open_files.rs
@@ -10,7 +10,9 @@ fn open_files() {
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
     let mut volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
         VolumeManager::new_with_limits(disk, time_source, 0xAA00_0000);
-    let volume = volume_mgr.open_volume(VolumeIdx(0)).expect("open volume");
+    let volume = volume_mgr
+        .open_raw_volume(VolumeIdx(0))
+        .expect("open volume");
     let root_dir = volume_mgr.open_root_dir(volume).expect("open root dir");
 
     // Open with string
@@ -18,10 +20,10 @@ fn open_files() {
         .open_file_in_dir(root_dir, "README.TXT", Mode::ReadWriteTruncate)
         .expect("open file");
 
-    let r = volume_mgr.open_file_in_dir(root_dir, "README.TXT", Mode::ReadOnly);
-    let Err(Error::FileAlreadyOpen) = r else {
-        panic!("Expected to not open file twice: {r:?}");
-    };
+    assert!(matches!(
+        volume_mgr.open_file_in_dir(root_dir, "README.TXT", Mode::ReadOnly),
+        Err(Error::FileAlreadyOpen)
+    ));
 
     volume_mgr.close_file(f).expect("close file");
 
@@ -35,35 +37,38 @@ fn open_files() {
         .open_file_in_dir(root_dir, &dir_entry.name, Mode::ReadWriteCreateOrAppend)
         .expect("open file with dir entry");
 
-    let r = volume_mgr.open_file_in_dir(root_dir, &dir_entry.name, Mode::ReadOnly);
-    let Err(Error::FileAlreadyOpen) = r else {
-        panic!("Expected to not open file twice: {r:?}");
-    };
+    assert!(matches!(
+        volume_mgr.open_file_in_dir(root_dir, &dir_entry.name, Mode::ReadOnly),
+        Err(Error::FileAlreadyOpen)
+    ));
 
     // Can still spot duplicates even if name given the other way around
-    let r = volume_mgr.open_file_in_dir(root_dir, "README.TXT", Mode::ReadOnly);
-    let Err(Error::FileAlreadyOpen) = r else {
-        panic!("Expected to not open file twice: {r:?}");
-    };
+
+    assert!(matches!(
+        volume_mgr.open_file_in_dir(root_dir, "README.TXT", Mode::ReadOnly),
+        Err(Error::FileAlreadyOpen)
+    ));
 
     let f2 = volume_mgr
         .open_file_in_dir(root_dir, "64MB.DAT", Mode::ReadWriteTruncate)
         .expect("open file");
 
     // Hit file limit
-    let r = volume_mgr.open_file_in_dir(root_dir, "EMPTY.DAT", Mode::ReadOnly);
-    let Err(Error::TooManyOpenFiles) = r else {
-        panic!("Expected to run out of file handles: {r:?}");
-    };
+
+    assert!(matches!(
+        volume_mgr.open_file_in_dir(root_dir, "EMPTY.DAT", Mode::ReadOnly),
+        Err(Error::TooManyOpenFiles)
+    ));
 
     volume_mgr.close_file(f).expect("close file");
     volume_mgr.close_file(f2).expect("close file");
 
     // File not found
-    let r = volume_mgr.open_file_in_dir(root_dir, "README.TXS", Mode::ReadOnly);
-    let Err(Error::FileNotFound) = r else {
-        panic!("Expected to not open missing file: {r:?}");
-    };
+
+    assert!(matches!(
+        volume_mgr.open_file_in_dir(root_dir, "README.TXS", Mode::ReadOnly),
+        Err(Error::FileNotFound)
+    ));
 
     // Create a new file
     let f3 = volume_mgr
@@ -84,6 +89,53 @@ fn open_files() {
 
     volume_mgr.close_dir(root_dir).expect("close dir");
     volume_mgr.close_volume(volume).expect("close volume");
+}
+
+#[test]
+fn open_non_raw() {
+    let time_source = utils::make_time_source();
+    let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
+    let mut volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
+        VolumeManager::new_with_limits(disk, time_source, 0xAA00_0000);
+    let mut volume = volume_mgr.open_volume(VolumeIdx(0)).expect("open volume");
+    let mut root_dir = volume.open_root_dir().expect("open root dir");
+    let mut f = root_dir
+        .open_file_in_dir("README.TXT", Mode::ReadOnly)
+        .expect("open file");
+
+    let mut buffer = [0u8; 512];
+    let len = f.read(&mut buffer).expect("read from file");
+    // See directory listing in utils.rs, to see that README.TXT is 258 bytes long
+    assert_eq!(len, 258);
+    assert_eq!(f.length(), 258);
+    f.seek_from_current(0).unwrap();
+    assert_eq!(f.is_eof(), true);
+    assert_eq!(f.offset(), 258);
+    assert!(matches!(f.seek_from_current(1), Err(Error::InvalidOffset)));
+    f.seek_from_current(-258).unwrap();
+    assert_eq!(f.is_eof(), false);
+    assert_eq!(f.offset(), 0);
+    f.seek_from_current(10).unwrap();
+    assert_eq!(f.is_eof(), false);
+    assert_eq!(f.offset(), 10);
+    f.seek_from_end(0).unwrap();
+    assert_eq!(f.is_eof(), true);
+    assert_eq!(f.offset(), 258);
+    assert!(matches!(
+        f.seek_from_current(-259),
+        Err(Error::InvalidOffset)
+    ));
+    f.seek_from_start(25).unwrap();
+    assert_eq!(f.is_eof(), false);
+    assert_eq!(f.offset(), 25);
+
+    drop(f);
+
+    let Err(Error::FileAlreadyExists) =
+        root_dir.open_file_in_dir("README.TXT", Mode::ReadWriteCreate)
+    else {
+        panic!("Expected to file to exist");
+    };
 }
 
 // ****************************************************************************

--- a/tests/read_file.rs
+++ b/tests/read_file.rs
@@ -1,9 +1,11 @@
 //! Reading related tests
 
+use sha2::Digest;
+
 mod utils;
 
-static TEST_DAT_SHA256_SUM: &str =
-    "59e3468e3bef8bfe37e60a8221a1896e105b80a61a23637612ac8cd24ca04a75";
+static TEST_DAT_SHA256_SUM: &[u8] =
+    b"\x59\xe3\x46\x8e\x3b\xef\x8b\xfe\x37\xe6\x0a\x82\x21\xa1\x89\x6e\x10\x5b\x80\xa6\x1a\x23\x63\x76\x12\xac\x8c\xd2\x4c\xa0\x4a\x75";
 
 #[test]
 fn read_file_512_blocks() {
@@ -41,8 +43,10 @@ fn read_file_512_blocks() {
         contents.extend(&buffer[0..len]);
     }
 
-    let hash = sha256::digest(contents);
-    assert_eq!(&hash, TEST_DAT_SHA256_SUM);
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(contents);
+    let hash = hasher.finalize();
+    assert_eq!(&hash[..], TEST_DAT_SHA256_SUM);
 }
 
 #[test]
@@ -73,8 +77,10 @@ fn read_file_all() {
         panic!("Failed to read all of TEST.DAT");
     }
 
-    let hash = sha256::digest(&contents[0..3500]);
-    assert_eq!(&hash, TEST_DAT_SHA256_SUM);
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(&contents[0..3500]);
+    let hash = hasher.finalize();
+    assert_eq!(&hash[..], TEST_DAT_SHA256_SUM);
 }
 
 #[test]
@@ -114,8 +120,10 @@ fn read_file_prime_blocks() {
         contents.extend(&buffer[0..len]);
     }
 
-    let hash = sha256::digest(contents);
-    assert_eq!(&hash, TEST_DAT_SHA256_SUM);
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(&contents[0..3500]);
+    let hash = hasher.finalize();
+    assert_eq!(&hash[..], TEST_DAT_SHA256_SUM);
 }
 
 #[test]
@@ -166,8 +174,10 @@ fn read_file_backwards() {
 
     let flat: Vec<u8> = contents.iter().flatten().copied().collect();
 
-    let hash = sha256::digest(flat);
-    assert_eq!(&hash, TEST_DAT_SHA256_SUM);
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(flat);
+    let hash = hasher.finalize();
+    assert_eq!(&hash[..], TEST_DAT_SHA256_SUM);
 }
 
 // ****************************************************************************

--- a/tests/read_file.rs
+++ b/tests/read_file.rs
@@ -12,7 +12,7 @@ fn read_file_512_blocks() {
     let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat16_volume = volume_mgr
-        .open_volume(embedded_sdmmc::VolumeIdx(0))
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
         .expect("open volume 0");
     let root_dir = volume_mgr
         .open_root_dir(fat16_volume)
@@ -52,7 +52,7 @@ fn read_file_all() {
     let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat16_volume = volume_mgr
-        .open_volume(embedded_sdmmc::VolumeIdx(0))
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
         .expect("open volume 0");
     let root_dir = volume_mgr
         .open_root_dir(fat16_volume)
@@ -84,7 +84,7 @@ fn read_file_prime_blocks() {
     let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat16_volume = volume_mgr
-        .open_volume(embedded_sdmmc::VolumeIdx(0))
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
         .expect("open volume 0");
     let root_dir = volume_mgr
         .open_root_dir(fat16_volume)
@@ -125,7 +125,7 @@ fn read_file_backwards() {
     let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat16_volume = volume_mgr
-        .open_volume(embedded_sdmmc::VolumeIdx(0))
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
         .expect("open volume 0");
     let root_dir = volume_mgr
         .open_root_dir(fat16_volume)

--- a/tests/volume.rs
+++ b/tests/volume.rs
@@ -16,60 +16,60 @@ fn open_all_volumes() {
 
     // Open Volume 0
     let fat16_volume = volume_mgr
-        .open_volume(embedded_sdmmc::VolumeIdx(0))
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
         .expect("open volume 0");
 
     // Fail to Open Volume 0 again
-    let r = volume_mgr.open_volume(embedded_sdmmc::VolumeIdx(0));
-    let Err(embedded_sdmmc::Error::VolumeAlreadyOpen) = r else {
-        panic!("Should have failed to open volume {:?}", r);
-    };
+    assert!(matches!(
+        volume_mgr.open_raw_volume(embedded_sdmmc::VolumeIdx(0)),
+        Err(embedded_sdmmc::Error::VolumeAlreadyOpen)
+    ));
 
     volume_mgr.close_volume(fat16_volume).expect("close fat16");
 
     // Open Volume 1
     let fat32_volume = volume_mgr
-        .open_volume(embedded_sdmmc::VolumeIdx(1))
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(1))
         .expect("open volume 1");
 
     // Fail to Volume 1 again
-    let r = volume_mgr.open_volume(embedded_sdmmc::VolumeIdx(1));
-    let Err(embedded_sdmmc::Error::VolumeAlreadyOpen) = r else {
-        panic!("Should have failed to open volume {:?}", r);
-    };
+    assert!(matches!(
+        volume_mgr.open_raw_volume(embedded_sdmmc::VolumeIdx(1)),
+        Err(embedded_sdmmc::Error::VolumeAlreadyOpen)
+    ));
 
     // Open Volume 0 again
     let fat16_volume = volume_mgr
-        .open_volume(embedded_sdmmc::VolumeIdx(0))
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
         .expect("open volume 0");
 
     // Open any volume - too many volumes (0 and 1 are open)
-    let r = volume_mgr.open_volume(embedded_sdmmc::VolumeIdx(0));
-    let Err(embedded_sdmmc::Error::TooManyOpenVolumes) = r else {
-        panic!("Should have failed to open volume {:?}", r);
-    };
+    assert!(matches!(
+        volume_mgr.open_raw_volume(embedded_sdmmc::VolumeIdx(0)),
+        Err(embedded_sdmmc::Error::TooManyOpenVolumes)
+    ));
 
     volume_mgr.close_volume(fat16_volume).expect("close fat16");
     volume_mgr.close_volume(fat32_volume).expect("close fat32");
 
     // This isn't a valid volume
-    let r = volume_mgr.open_volume(embedded_sdmmc::VolumeIdx(2));
-    let Err(embedded_sdmmc::Error::FormatError(_e)) = r else {
-        panic!("Should have failed to open volume {:?}", r);
-    };
+    assert!(matches!(
+        volume_mgr.open_raw_volume(embedded_sdmmc::VolumeIdx(2)),
+        Err(embedded_sdmmc::Error::FormatError(_e))
+    ));
 
     // This isn't a valid volume
-    let r = volume_mgr.open_volume(embedded_sdmmc::VolumeIdx(9));
-    let Err(embedded_sdmmc::Error::NoSuchVolume) = r else {
-        panic!("Should have failed to open volume {:?}", r);
-    };
+    assert!(matches!(
+        volume_mgr.open_raw_volume(embedded_sdmmc::VolumeIdx(9)),
+        Err(embedded_sdmmc::Error::NoSuchVolume)
+    ));
 
     let _root_dir = volume_mgr.open_root_dir(fat32_volume).expect("Open dir");
 
-    let r = volume_mgr.close_volume(fat32_volume);
-    let Err(embedded_sdmmc::Error::VolumeStillInUse) = r else {
-        panic!("Should have failed to close volume {:?}", r);
-    };
+    assert!(matches!(
+        volume_mgr.close_volume(fat32_volume),
+        Err(embedded_sdmmc::Error::VolumeStillInUse)
+    ));
 }
 
 #[test]
@@ -79,15 +79,15 @@ fn close_volume_too_early() {
     let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let volume = volume_mgr
-        .open_volume(embedded_sdmmc::VolumeIdx(0))
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
         .expect("open volume 0");
     let root_dir = volume_mgr.open_root_dir(volume).expect("open root dir");
 
     // Dir open
-    let r = volume_mgr.close_volume(volume);
-    let Err(embedded_sdmmc::Error::VolumeStillInUse) = r else {
-        panic!("Expected failure to close volume: {r:?}");
-    };
+    assert!(matches!(
+        volume_mgr.close_volume(volume),
+        Err(embedded_sdmmc::Error::VolumeStillInUse)
+    ));
 
     let _test_file = volume_mgr
         .open_file_in_dir(root_dir, "64MB.DAT", embedded_sdmmc::Mode::ReadOnly)
@@ -96,10 +96,10 @@ fn close_volume_too_early() {
     volume_mgr.close_dir(root_dir).unwrap();
 
     // File open, not dir open
-    let r = volume_mgr.close_volume(volume);
-    let Err(embedded_sdmmc::Error::VolumeStillInUse) = r else {
-        panic!("Expected failure to close volume: {r:?}");
-    };
+    assert!(matches!(
+        volume_mgr.close_volume(volume),
+        Err(embedded_sdmmc::Error::VolumeStillInUse)
+    ));
 }
 
 // ****************************************************************************

--- a/tests/write_file.rs
+++ b/tests/write_file.rs
@@ -10,7 +10,9 @@ fn append_file() {
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
     let mut volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
         VolumeManager::new_with_limits(disk, time_source, 0xAA00_0000);
-    let volume = volume_mgr.open_volume(VolumeIdx(0)).expect("open volume");
+    let volume = volume_mgr
+        .open_raw_volume(VolumeIdx(0))
+        .expect("open volume");
     let root_dir = volume_mgr.open_root_dir(volume).expect("open root dir");
 
     // Open with string


### PR DESCRIPTION
`Volume`, `Directory` and `File` now hold `&mut VolumeManager`, which gives them methods and a `Drop` impl. Old functionality available with `RawVolume`, `RawDirectory` and `RawFile` because with the smart handles you can't open more than one file at once.
