### PR TITLE
Linked no-std examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ let mut cont: VolumeManager<_, _, 6, 12, 4> = VolumeManager::new_with_limits(blo
 This repository houses no examples for no-std usage, however you can check out the following examples:
 - [Pi Pico](https://github.com/rp-rs/rp-hal-boards/blob/main/boards/rp-pico/examples/pico_spi_sd_card.rs)
 - [STM32H7XX](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/sdmmc_fat.rs)
+- [atsamd(pygamer)](https://github.com/atsamd-rs/atsamd/blob/master/boards/pygamer/examples/sd_card.rs)
 
 ## Todo List (PRs welcome!)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ let mut cont: VolumeManager<_, _, 6, 12, 4> = VolumeManager::new_with_limits(blo
 * Iterate sub-directories
 * Log over defmt or the common log interface (feature flags).
 
+## No-std usage
+This repository houses no examples for no-std usage, however you can check out the following examples:
+- [Pi Pico](https://github.com/rp-rs/rp-hal-boards/blob/main/boards/rp-pico/examples/pico_spi_sd_card.rs)
+- [STM32H7XX](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/sdmmc_fat.rs)
+
 ## Todo List (PRs welcome!)
 
 * Create new dirs


### PR DESCRIPTION
As mentioned in #107 this would directly link some no-std examples of using the crate, making it easier for new users to get started