### PR TITLE
Fix struct reference in documentation

### DIFF
--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -51,7 +51,7 @@ pub struct DirEntry {
 pub struct RawDirectory(pub(crate) SearchId);
 
 impl RawDirectory {
-    /// Convert a raw file into a droppable [`File`]
+    /// Convert a raw file into a droppable [`crate::filesystem::File`]
     pub fn to_directory<
         D,
         T,


### PR DESCRIPTION
I tried to work with the smart handles version of this library.
But I got a warning from `cargo doc`.

```
warning: unresolved link to `File`
  --> src/filesystem/directory.rs:54:47
   |
54 |     /// Convert a raw file into a droppable [`File`]
   |                                               ^^^^ no item named `File` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: `embedded-sdmmc` (lib doc) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
```

This PR fixes it.