### PR TITLE
Fix issue 74

### DIFF
--- a/examples/big_dir.rs
+++ b/examples/big_dir.rs
@@ -1,0 +1,39 @@
+extern crate embedded_sdmmc;
+
+mod linux;
+use linux::*;
+
+use embedded_sdmmc::{Error, VolumeManager};
+
+fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
+    env_logger::init();
+    let mut args = std::env::args().skip(1);
+    let filename = args.next().unwrap_or_else(|| "/dev/mmcblk0".into());
+    let print_blocks = args.find(|x| x == "-v").map(|_| true).unwrap_or(false);
+    let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
+    let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
+        VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
+    let mut volume = volume_mgr
+        .open_volume(embedded_sdmmc::VolumeIdx(1))
+        .unwrap();
+    println!("Volume: {:?}", volume);
+    let mut root_dir = volume.open_root_dir().unwrap();
+
+    let mut file_num = 0;
+    loop {
+        file_num += 1;
+        let file_name = format!("{}.da", file_num);
+        println!("opening file {file_name} for writing");
+        let mut file = root_dir
+            .open_file_in_dir(
+                file_name.as_str(),
+                embedded_sdmmc::Mode::ReadWriteCreateOrTruncate,
+            )
+            .unwrap();
+        let buf = b"hello world, from rust";
+        println!("writing to file");
+        file.write(&buf[..]).unwrap();
+        println!("closing file");
+        drop(file);
+    }
+}


### PR DESCRIPTION
Map ROOT_DIR (0xFFFF_FFFC) to an actual cluster number, so if you go off the end of the first cluster of the root directory on FAT32, the code no longer crashes trying to convert the ROOT_DIR magic cluster number into a disk offset.

Also adds an example which replicates the issue by writing an infinite number of files to the root directory.

Closes #74 