### PR TITLE
Always closing (and more)

### DIFF
--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -775,14 +775,36 @@ where
 
     /// Close a file with the given raw file handle.
     pub fn close_file(&mut self, file: RawFile) -> Result<(), Error<D::Error>> {
-        let file_idx = self.flush_file_get_index(file)?;
+        let flush_result = self.flush_file(file);
+        let file_idx = self.get_file_by_id(file)?;
         self.open_files.swap_remove(file_idx);
-        Ok(())
+        flush_result
     }
 
     /// Flush (update the entry) for a file with the given raw file handle.
     pub fn flush_file(&mut self, file: RawFile) -> Result<(), Error<D::Error>> {
-        self.flush_file_get_index(file).map(|_| ())
+        let file_info = self
+            .open_files
+            .iter()
+            .find(|info| info.file_id == file)
+            .ok_or(Error::BadHandle)?;
+
+        if file_info.dirty {
+            let volume_idx = self.get_volume_by_id(file_info.volume_id)?;
+            match self.open_volumes[volume_idx].volume_type {
+                VolumeType::Fat(ref mut fat) => {
+                    debug!("Updating FAT info sector");
+                    fat.update_info_sector(&self.block_device)?;
+                    debug!("Updating dir entry {:?}", file_info.entry);
+                    if file_info.entry.size != 0 {
+                        // If you have a length, you must have a cluster
+                        assert!(file_info.entry.cluster.0 != 0);
+                    }
+                    fat.write_entry_to_disk(&self.block_device, &file_info.entry)?;
+                }
+            };
+        }
+        Ok(())
     }
 
     /// Check if any files or folders are open.
@@ -1053,38 +1075,6 @@ where
         let block_offset = (desired_offset % Block::LEN_U32) as usize;
         let available = Block::LEN - block_offset;
         Ok((block_idx, block_offset, available))
-    }
-
-    /// Flush (update the entry) for a file with the given raw file handle and
-    /// get its index.
-    fn flush_file_get_index(&mut self, file: RawFile) -> Result<usize, Error<D::Error>> {
-        let mut found_idx = None;
-        for (idx, info) in self.open_files.iter().enumerate() {
-            if file == info.file_id {
-                found_idx = Some((info, idx));
-                break;
-            }
-        }
-
-        let (file_info, file_idx) = found_idx.ok_or(Error::BadHandle)?;
-
-        if file_info.dirty {
-            let volume_idx = self.get_volume_by_id(file_info.volume_id)?;
-            match self.open_volumes[volume_idx].volume_type {
-                VolumeType::Fat(ref mut fat) => {
-                    debug!("Updating FAT info sector");
-                    fat.update_info_sector(&self.block_device)?;
-                    debug!("Updating dir entry {:?}", file_info.entry);
-                    if file_info.entry.size != 0 {
-                        // If you have a length, you must have a cluster
-                        assert!(file_info.entry.cluster.0 != 0);
-                    }
-                    fat.write_entry_to_disk(&self.block_device, &file_info.entry)?;
-                }
-            };
-        }
-
-        Ok(file_idx)
     }
 }
 


### PR DESCRIPTION
Answering my own issue #122 with this one.

When calling `VolumeManager::close_file(..)` one would expect the file index to actually be removed from the volume manager, even if flushing the data to the card fails. This is currently not the case due to any errors during flushing short-circuiting the error. This PR addresses that.

I have also taken some the liberties in turning some for-loop searches into iterators, and removed panicking behavior from the `impl Drop`s on volumes, directories and files.