### PR TITLE
implement FAT table write/read and setting the volume dirty status

### DIFF
--- a/src/fat/fat_table.rs
+++ b/src/fat/fat_table.rs
@@ -1,0 +1,62 @@
+/// FAT table definition
+///
+///
+use crate::fat::FatType;
+use byteorder::{ByteOrder, LittleEndian};
+
+/// Represents a single FAT table. It contains all information about which cluster is occupied
+/// from a file
+pub struct FatTable<'a> {
+    fat_type: FatType,
+    data: &'a mut [u8],
+}
+
+impl<'a> FatTable<'a> {
+    /// Attempt to parse a FAT table from a multiple sectors.
+    pub fn create_from_bytes(data: &'a mut [u8], fat_type: FatType) -> Result<Self, &'static str> {
+        Ok(Self { data, fat_type })
+    }
+
+    // FAT16 only
+    //define_field!(fat_id16, u16, 0);
+
+    // FAT32 only
+    //define_field!(fat_id32, u32, 0);
+
+    const FAT16_DIRTY_BIT: u16 = 15;
+    const FAT32_DIRTY_BIT: u32 = 27;
+
+    pub(crate) fn dirty(&self) -> bool {
+        match self.fat_type {
+            FatType::Fat16 => {
+                (LittleEndian::read_u16(&self.data[2..2 + 2]) & (1 << Self::FAT16_DIRTY_BIT)) == 0
+            }
+            FatType::Fat32 => {
+                (LittleEndian::read_u32(&self.data[4..4 + 4]) & (1 << Self::FAT32_DIRTY_BIT)) == 0
+            }
+        }
+    }
+
+    pub(crate) fn set_dirty(&mut self, dirty: bool) {
+        match self.fat_type {
+            FatType::Fat16 => {
+                let mut v = LittleEndian::read_u16(&self.data[2..2 + 2]);
+                if dirty {
+                    v &= !(1 << Self::FAT16_DIRTY_BIT);
+                } else {
+                    v |= 1 << Self::FAT16_DIRTY_BIT
+                }
+                LittleEndian::write_u16(&mut self.data[2..2 + 2], v);
+            }
+            FatType::Fat32 => {
+                let mut v = LittleEndian::read_u32(&self.data[4..4 + 4]);
+                if dirty {
+                    v &= !(1 << Self::FAT32_DIRTY_BIT);
+                } else {
+                    v |= 1 << Self::FAT32_DIRTY_BIT
+                }
+                LittleEndian::write_u32(&mut self.data[4..4 + 4], v);
+            }
+        }
+    }
+}

--- a/src/fat/mod.rs
+++ b/src/fat/mod.rs
@@ -45,11 +45,13 @@ impl BlockCache {
 }
 
 mod bpb;
+mod fat_table;
 mod info;
 mod ondiskdirentry;
 mod volume;
 
 pub use bpb::Bpb;
+pub use fat_table::FatTable;
 pub use info::{Fat16Info, Fat32Info, FatSpecificInfo, InfoSector};
 pub use ondiskdirentry::OnDiskDirEntry;
 pub use volume::{parse_volume, FatVolume, VolumeName};

--- a/src/fat/volume.rs
+++ b/src/fat/volume.rs
@@ -55,6 +55,10 @@ pub struct FatVolume {
     /// The block the FAT starts in. Relative to start of partition (so add
     /// `self.lba_offset` before passing to volume manager)
     pub(crate) fat_start: BlockCount,
+    /// Size of the FAT table in blocks
+    pub(crate) fat_size: BlockCount,
+    /// Number of FAT tables (Normaly there are 2 which are always synchronized (backup))
+    pub(crate) fat_nums: u8,
     /// Expected number of free clusters
     pub(crate) free_clusters_count: Option<u32>,
     /// Number of the next expected free cluster
@@ -1098,6 +1102,8 @@ where
                 blocks_per_cluster: bpb.blocks_per_cluster(),
                 first_data_block: (first_data_block),
                 fat_start: BlockCount(u32::from(bpb.reserved_block_count())),
+                fat_size: BlockCount(bpb.fat_size()),
+                fat_nums: bpb.num_fats(),
                 free_clusters_count: None,
                 next_free_cluster: None,
                 cluster_count: bpb.total_clusters(),
@@ -1135,6 +1141,8 @@ where
                 blocks_per_cluster: bpb.blocks_per_cluster(),
                 first_data_block: BlockCount(first_data_block),
                 fat_start: BlockCount(u32::from(bpb.reserved_block_count())),
+                fat_size: BlockCount(bpb.fat_size()),
+                fat_nums: bpb.num_fats(),
                 free_clusters_count: info_sector.free_clusters_count(),
                 next_free_cluster: info_sector.next_free_cluster(),
                 cluster_count: bpb.total_clusters(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,10 @@ where
     VolumeStillInUse,
     /// You can't open a volume twice
     VolumeAlreadyOpen,
+    /// Volume is opened in read only mode
+    VolumeReadOnly,
+    /// Fat table is longer than supported
+    FatTableTooLarge,
     /// We can't do that yet
     Unsupported,
     /// Tried to read beyond end of file
@@ -344,6 +348,8 @@ pub(crate) struct VolumeInfo {
     idx: VolumeIdx,
     /// What kind of volume this is
     volume_type: VolumeType,
+    /// Flag to indicate if the volume was opened as read only. If read only, files cannot be opened in write mode!
+    read_only: bool,
 }
 
 /// This enum holds the data for the various different types of filesystems we


### PR DESCRIPTION
The dirty flag will be set when opening the volume to indicate that the FAT table might be out of date. In case of an unexpected close without unmount in the next mount it is visible that the FAT table is outdated and can be reread by the operating system (https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system). Without this, the file must always closed before removing the sd card because otherwise the FAT table is outdated and so the files are not visible when mounting the sd card on a computer. For embedded systems it is quite likely that unexpect end can happen and always closing the file after a single write operation is a performance issue. For readonly this dirty flag is not required and therefore it will not set and reset when opening/closing a volume. This is same as the linux kernel is doing.

https://unix.stackexchange.com/questions/230181/why-does-linux-mark-fat-as-dirty-simply-due-to-mounting-it Linux 

kernel is doing it during mount, so there is no need to ckeck it every time during a new write