### PR TITLE
Use a RefCell to provide interior mutability for VolumeManager.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ let sdcard = embedded_sdmmc::SdCard::new(sdmmc_spi, delay);
 println!("Card size is {} bytes", sdcard.num_bytes()?);
 // Now let's look for volumes (also known as partitions) on our block device.
 // To do this we need a Volume Manager. It will take ownership of the block device.
-let mut volume_mgr = embedded_sdmmc::VolumeManager::new(sdcard, time_source);
+let volume_mgr = embedded_sdmmc::VolumeManager::new(sdcard, time_source);
 // Try and access Volume 0 (i.e. the first partition).
 // The volume object holds information about the filesystem on that volume.
-let mut volume0 = volume_mgr.open_volume(embedded_sdmmc::VolumeIdx(0))?;
+let volume0 = volume_mgr.open_volume(embedded_sdmmc::VolumeIdx(0))?;
 println!("Volume 0: {:?}", volume0);
 // Open the root directory (mutably borrows from the volume).
-let mut root_dir = volume0.open_root_dir()?;
+let root_dir = volume0.open_root_dir()?;
 // Open a file called "MY_FILE.TXT" in the root directory
 // This mutably borrows the directory.
-let mut my_file = root_dir.open_file_in_dir("MY_FILE.TXT", embedded_sdmmc::Mode::ReadOnly)?;
+let my_file = root_dir.open_file_in_dir("MY_FILE.TXT", embedded_sdmmc::Mode::ReadOnly)?;
 // Print the contents of the file, assuming it's in ISO-8859-1 encoding
 while !my_file.is_eof() {
     let mut buffer = [0u8; 32];
@@ -43,7 +43,7 @@ By default the `VolumeManager` will initialize with a maximum number of `4` open
 
 ```rust
 // Create a volume manager with a maximum of 6 open directories, 12 open files, and 4 volumes (or partitions)
-let mut cont: VolumeManager<_, _, 6, 12, 4> = VolumeManager::new_with_limits(block, time_source);
+let cont: VolumeManager<_, _, 6, 12, 4> = VolumeManager::new_with_limits(block, time_source);
 ```
 
 ## Supported features

--- a/examples/append_file.rs
+++ b/examples/append_file.rs
@@ -30,12 +30,12 @@ fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
     let filename = args.next().unwrap_or_else(|| "/dev/mmcblk0".into());
     let print_blocks = args.find(|x| x == "-v").map(|_| true).unwrap_or(false);
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
-    let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
+    let volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let mut volume = volume_mgr.open_volume(VolumeIdx(0))?;
-    let mut root_dir = volume.open_root_dir()?;
+    let volume = volume_mgr.open_volume(VolumeIdx(0))?;
+    let root_dir = volume.open_root_dir()?;
     println!("\nCreating file {}...", FILE_TO_APPEND);
-    let mut f = root_dir.open_file_in_dir(FILE_TO_APPEND, Mode::ReadWriteAppend)?;
+    let f = root_dir.open_file_in_dir(FILE_TO_APPEND, Mode::ReadWriteAppend)?;
     f.write(b"\r\n\r\nThis has been added to your file.\r\n")?;
     Ok(())
 }

--- a/examples/big_dir.rs
+++ b/examples/big_dir.rs
@@ -11,20 +11,20 @@ fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
     let filename = args.next().unwrap_or_else(|| "/dev/mmcblk0".into());
     let print_blocks = args.find(|x| x == "-v").map(|_| true).unwrap_or(false);
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
-    let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
+    let volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let mut volume = volume_mgr
+    let volume = volume_mgr
         .open_volume(embedded_sdmmc::VolumeIdx(1))
         .unwrap();
     println!("Volume: {:?}", volume);
-    let mut root_dir = volume.open_root_dir().unwrap();
+    let root_dir = volume.open_root_dir().unwrap();
 
     let mut file_num = 0;
     loop {
         file_num += 1;
         let file_name = format!("{}.da", file_num);
         println!("opening file {file_name} for writing");
-        let mut file = root_dir
+        let file = root_dir
             .open_file_in_dir(
                 file_name.as_str(),
                 embedded_sdmmc::Mode::ReadWriteCreateOrTruncate,

--- a/examples/create_file.rs
+++ b/examples/create_file.rs
@@ -30,15 +30,15 @@ fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
     let filename = args.next().unwrap_or_else(|| "/dev/mmcblk0".into());
     let print_blocks = args.find(|x| x == "-v").map(|_| true).unwrap_or(false);
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
-    let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
+    let volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let mut volume = volume_mgr.open_volume(VolumeIdx(0))?;
-    let mut root_dir = volume.open_root_dir()?;
+    let volume = volume_mgr.open_volume(VolumeIdx(0))?;
+    let root_dir = volume.open_root_dir()?;
     println!("\nCreating file {}...", FILE_TO_CREATE);
     // This will panic if the file already exists: use ReadWriteCreateOrAppend
     // or ReadWriteCreateOrTruncate instead if you want to modify an existing
     // file.
-    let mut f = root_dir.open_file_in_dir(FILE_TO_CREATE, Mode::ReadWriteCreate)?;
+    let f = root_dir.open_file_in_dir(FILE_TO_CREATE, Mode::ReadWriteCreate)?;
     f.write(b"Hello, this is a new file on disk\r\n")?;
     Ok(())
 }

--- a/examples/delete_file.rs
+++ b/examples/delete_file.rs
@@ -33,10 +33,10 @@ fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
     let filename = args.next().unwrap_or_else(|| "/dev/mmcblk0".into());
     let print_blocks = args.find(|x| x == "-v").map(|_| true).unwrap_or(false);
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
-    let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
+    let volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let mut volume = volume_mgr.open_volume(VolumeIdx(0))?;
-    let mut root_dir = volume.open_root_dir()?;
+    let volume = volume_mgr.open_volume(VolumeIdx(0))?;
+    let root_dir = volume.open_root_dir()?;
     println!("Deleting file {}...", FILE_TO_DELETE);
     root_dir.delete_file_in_dir(FILE_TO_DELETE)?;
     println!("Deleted!");

--- a/examples/list_dir.rs
+++ b/examples/list_dir.rs
@@ -47,9 +47,9 @@ fn main() -> Result<(), Error> {
     let filename = args.next().unwrap_or_else(|| "/dev/mmcblk0".into());
     let print_blocks = args.find(|x| x == "-v").map(|_| true).unwrap_or(false);
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
-    let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
+    let volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let mut volume = volume_mgr.open_volume(VolumeIdx(0))?;
+    let volume = volume_mgr.open_volume(VolumeIdx(0))?;
     let root_dir = volume.open_root_dir()?;
     list_dir(root_dir, "/")?;
     Ok(())
@@ -59,7 +59,7 @@ fn main() -> Result<(), Error> {
 ///
 /// The path is for display purposes only.
 fn list_dir(
-    mut directory: Directory<LinuxBlockDevice, Clock, 8, 8, 4>,
+    directory: Directory<LinuxBlockDevice, Clock, 8, 8, 4>,
     path: &str,
 ) -> Result<(), Error> {
     println!("Listing {}", path);

--- a/examples/read_file.rs
+++ b/examples/read_file.rs
@@ -47,12 +47,15 @@ fn main() -> Result<(), embedded_sdmmc::Error<std::io::Error>> {
     let filename = args.next().unwrap_or_else(|| "/dev/mmcblk0".into());
     let print_blocks = args.find(|x| x == "-v").map(|_| true).unwrap_or(false);
     let lbd = LinuxBlockDevice::new(filename, print_blocks).map_err(Error::DeviceError)?;
-    let mut volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
+    let volume_mgr: VolumeManager<LinuxBlockDevice, Clock, 8, 8, 4> =
         VolumeManager::new_with_limits(lbd, Clock, 0xAA00_0000);
-    let mut volume = volume_mgr.open_volume(VolumeIdx(0))?;
-    let mut root_dir = volume.open_root_dir()?;
+    let volume = volume_mgr.open_volume(VolumeIdx(0))?;
+    let root_dir = volume.open_root_dir()?;
     println!("\nReading file {}...", FILE_TO_READ);
-    let mut f = root_dir.open_file_in_dir(FILE_TO_READ, Mode::ReadOnly)?;
+    let f = root_dir.open_file_in_dir(FILE_TO_READ, Mode::ReadOnly)?;
+    // Proves we can open two files at once now (or try to - this file doesn't exist)
+    let f2 = root_dir.open_file_in_dir("MISSING.DAT", Mode::ReadOnly);
+    assert!(f2.is_err());
     while !f.is_eof() {
         let mut buffer = [0u8; 16];
         let offset = f.offset();

--- a/examples/readme_test.rs
+++ b/examples/readme_test.rs
@@ -125,16 +125,16 @@ fn main() -> Result<(), Error> {
     println!("Card size is {} bytes", sdcard.num_bytes()?);
     // Now let's look for volumes (also known as partitions) on our block device.
     // To do this we need a Volume Manager. It will take ownership of the block device.
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(sdcard, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(sdcard, time_source);
     // Try and access Volume 0 (i.e. the first partition).
     // The volume object holds information about the filesystem on that volume.
-    let mut volume0 = volume_mgr.open_volume(embedded_sdmmc::VolumeIdx(0))?;
+    let volume0 = volume_mgr.open_volume(embedded_sdmmc::VolumeIdx(0))?;
     println!("Volume 0: {:?}", volume0);
     // Open the root directory (mutably borrows from the volume).
-    let mut root_dir = volume0.open_root_dir()?;
+    let root_dir = volume0.open_root_dir()?;
     // Open a file called "MY_FILE.TXT" in the root directory
     // This mutably borrows the directory.
-    let mut my_file = root_dir.open_file_in_dir("MY_FILE.TXT", embedded_sdmmc::Mode::ReadOnly)?;
+    let my_file = root_dir.open_file_in_dir("MY_FILE.TXT", embedded_sdmmc::Mode::ReadOnly)?;
     // Print the contents of the file, assuming it's in ISO-8859-1 encoding
     while !my_file.is_eof() {
         let mut buffer = [0u8; 32];

--- a/examples/shell.rs
+++ b/examples/shell.rs
@@ -250,13 +250,13 @@ impl Context {
         println!("Directory listing of {:?}", path);
         let dir = self.resolve_existing_directory(path)?;
         // tree_dir will close this directory, always
-        self.tree_dir(dir)
+        Self::tree_dir(dir)
     }
 
     /// Print a recursive directory listing for the given open directory.
     ///
     /// Will close the given directory.
-    fn tree_dir<'a>(&'a self, dir: Directory<'a>) -> Result<(), Error> {
+    fn tree_dir(dir: Directory) -> Result<(), Error> {
         let mut children = Vec::new();
         dir.iterate_dir(|entry| {
             println!(
@@ -272,17 +272,9 @@ impl Context {
         })?;
         for child in children {
             println!("Entering {}", child);
-            let child_dir = match dir.open_dir(&child) {
-                Ok(child_dir) => child_dir,
-                Err(e) => {
-                    return Err(e);
-                }
-            };
-            let result = self.tree_dir(child_dir);
+            let child_dir = dir.open_dir(&child)?;
+            Self::tree_dir(child_dir)?;
             println!("Returning from {}", child);
-            if let Err(e) = result {
-                return Err(e);
-            }
         }
         Ok(())
     }

--- a/examples/shell.rs
+++ b/examples/shell.rs
@@ -228,7 +228,7 @@ impl Context {
     fn dir(&mut self, path: &Path) -> Result<(), Error> {
         println!("Directory listing of {:?}", path);
         let dir = self.resolve_existing_directory(path)?;
-        let mut dir = dir.to_directory(&mut self.volume_mgr);
+        let dir = dir.to_directory(&mut self.volume_mgr);
         dir.iterate_dir(|entry| {
             if !entry.attributes.is_volume() && !entry.attributes.is_lfn() {
                 println!(
@@ -257,7 +257,7 @@ impl Context {
     ///
     /// Will close the given directory.
     fn tree_dir(&mut self, dir: RawDirectory) -> Result<(), Error> {
-        let mut dir = dir.to_directory(&mut self.volume_mgr);
+        let dir = dir.to_directory(&mut self.volume_mgr);
         let mut children = Vec::new();
         dir.iterate_dir(|entry| {
             println!(
@@ -329,8 +329,8 @@ impl Context {
     /// print a text file
     fn cat(&mut self, filename: &Path) -> Result<(), Error> {
         let (dir, filename) = self.resolve_filename(filename)?;
-        let mut dir = dir.to_directory(&mut self.volume_mgr);
-        let mut f = dir.open_file_in_dir(filename, embedded_sdmmc::Mode::ReadOnly)?;
+        let dir = dir.to_directory(&mut self.volume_mgr);
+        let f = dir.open_file_in_dir(filename, embedded_sdmmc::Mode::ReadOnly)?;
         let mut data = Vec::new();
         while !f.is_eof() {
             let mut buffer = vec![0u8; 65536];
@@ -350,8 +350,8 @@ impl Context {
     /// print a binary file
     fn hexdump(&mut self, filename: &Path) -> Result<(), Error> {
         let (dir, filename) = self.resolve_filename(filename)?;
-        let mut dir = dir.to_directory(&mut self.volume_mgr);
-        let mut f = dir.open_file_in_dir(filename, embedded_sdmmc::Mode::ReadOnly)?;
+        let dir = dir.to_directory(&mut self.volume_mgr);
+        let f = dir.open_file_in_dir(filename, embedded_sdmmc::Mode::ReadOnly)?;
         let mut data = Vec::new();
         while !f.is_eof() {
             let mut buffer = vec![0u8; 65536];
@@ -387,7 +387,7 @@ impl Context {
     /// create a directory
     fn mkdir(&mut self, dir_name: &Path) -> Result<(), Error> {
         let (dir, filename) = self.resolve_filename(dir_name)?;
-        let mut dir = dir.to_directory(&mut self.volume_mgr);
+        let dir = dir.to_directory(&mut self.volume_mgr);
         dir.make_dir_in_dir(filename)
     }
 

--- a/src/filesystem/cluster.rs
+++ b/src/filesystem/cluster.rs
@@ -3,7 +3,7 @@
 /// A cluster is a consecutive group of blocks. Each cluster has a a numeric ID.
 /// Some numeric IDs are reserved for special purposes.
 #[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct ClusterId(pub(crate) u32);
 
 impl ClusterId {
@@ -30,6 +30,34 @@ impl core::ops::Add<u32> for ClusterId {
 impl core::ops::AddAssign<u32> for ClusterId {
     fn add_assign(&mut self, rhs: u32) {
         self.0 += rhs;
+    }
+}
+
+impl core::fmt::Debug for ClusterId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "ClusterId(")?;
+        match *self {
+            Self::INVALID => {
+                write!(f, "INVALID")?;
+            }
+            Self::BAD => {
+                write!(f, "BAD")?;
+            }
+            Self::EMPTY => {
+                write!(f, "EMPTY")?;
+            }
+            Self::ROOT_DIR => {
+                write!(f, "ROOT_DIR")?;
+            }
+            Self::END_OF_FILE => {
+                write!(f, "END_OF_FILE")?;
+            }
+            ClusterId(value) => {
+                write!(f, "{:#08x}", value)?;
+            }
+        }
+        write!(f, ")")?;
+        Ok(())
     }
 }
 

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -144,6 +144,14 @@ where
     }
 
     /// Call a callback function for each directory entry in a directory.
+    ///
+    /// <div class="warning">
+    ///
+    /// Do not attempt to call any methods on the VolumeManager or any of its
+    /// handles from inside the callback. You will get a lock error because the
+    /// object is already locked in order to do the iteration.
+    ///
+    /// </div>
     pub fn iterate_dir<F>(&self, func: F) -> Result<(), Error<D::Error>>
     where
         F: FnMut(&DirEntry),

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -57,7 +57,7 @@ impl RawDirectory {
         const MAX_VOLUMES: usize,
     >(
         self,
-        volume_mgr: &mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+        volume_mgr: &VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
     ) -> Directory<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
     where
         D: crate::BlockDevice,
@@ -87,7 +87,7 @@ pub struct Directory<
     T: crate::TimeSource,
 {
     raw_directory: RawDirectory,
-    volume_mgr: &'a mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+    volume_mgr: &'a VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
 }
 
 impl<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
@@ -99,7 +99,7 @@ where
     /// Create a new `Directory` from a `RawDirectory`
     pub fn new(
         raw_directory: RawDirectory,
-        volume_mgr: &'a mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+        volume_mgr: &'a VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
     ) -> Directory<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES> {
         Directory {
             raw_directory,
@@ -111,7 +111,7 @@ where
     ///
     /// You can then read the directory entries with `iterate_dir` and `open_file_in_dir`.
     pub fn open_dir<N>(
-        &mut self,
+        &self,
         name: N,
     ) -> Result<Directory<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>>
     where
@@ -135,7 +135,7 @@ where
     }
 
     /// Look in a directory for a named file.
-    pub fn find_directory_entry<N>(&mut self, name: N) -> Result<DirEntry, Error<D::Error>>
+    pub fn find_directory_entry<N>(&self, name: N) -> Result<DirEntry, Error<D::Error>>
     where
         N: ToShortFileName,
     {
@@ -144,7 +144,7 @@ where
     }
 
     /// Call a callback function for each directory entry in a directory.
-    pub fn iterate_dir<F>(&mut self, func: F) -> Result<(), Error<D::Error>>
+    pub fn iterate_dir<F>(&self, func: F) -> Result<(), Error<D::Error>>
     where
         F: FnMut(&DirEntry),
     {
@@ -153,7 +153,7 @@ where
 
     /// Open a file with the given full path. A file can only be opened once.
     pub fn open_file_in_dir<N>(
-        &mut self,
+        &self,
         name: N,
         mode: crate::Mode,
     ) -> Result<crate::File<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, crate::Error<D::Error>>
@@ -167,7 +167,7 @@ where
     }
 
     /// Delete a closed file with the given filename, if it exists.
-    pub fn delete_file_in_dir<N>(&mut self, name: N) -> Result<(), Error<D::Error>>
+    pub fn delete_file_in_dir<N>(&self, name: N) -> Result<(), Error<D::Error>>
     where
         N: ToShortFileName,
     {
@@ -175,7 +175,7 @@ where
     }
 
     /// Make a directory inside this directory
-    pub fn make_dir_in_dir<N>(&mut self, name: N) -> Result<(), Error<D::Error>>
+    pub fn make_dir_in_dir<N>(&self, name: N) -> Result<(), Error<D::Error>>
     where
         N: ToShortFileName,
     {
@@ -239,9 +239,9 @@ where
 #[derive(Debug, Clone)]
 pub(crate) struct DirectoryInfo {
     /// The handle for this directory.
-    pub(crate) directory_id: RawDirectory,
+    pub(crate) raw_directory: RawDirectory,
     /// The handle for the volume this directory is on
-    pub(crate) volume_id: RawVolume,
+    pub(crate) raw_volume: RawVolume,
     /// The starting point of the directory listing.
     pub(crate) cluster: ClusterId,
 }

--- a/src/filesystem/files.rs
+++ b/src/filesystem/files.rs
@@ -29,7 +29,7 @@ impl RawFile {
     /// Convert a raw file into a droppable [`File`]
     pub fn to_file<D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>(
         self,
-        volume_mgr: &mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+        volume_mgr: &VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
     ) -> File<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
     where
         D: crate::BlockDevice,
@@ -53,7 +53,7 @@ where
     T: crate::TimeSource,
 {
     raw_file: RawFile,
-    volume_mgr: &'a mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+    volume_mgr: &'a VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
 }
 
 impl<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
@@ -65,7 +65,7 @@ where
     /// Create a new `File` from a `RawFile`
     pub fn new(
         raw_file: RawFile,
-        volume_mgr: &'a mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+        volume_mgr: &'a VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
     ) -> File<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES> {
         File {
             raw_file,
@@ -76,12 +76,12 @@ where
     /// Read from the file
     ///
     /// Returns how many bytes were read, or an error.
-    pub fn read(&mut self, buffer: &mut [u8]) -> Result<usize, crate::Error<D::Error>> {
+    pub fn read(&self, buffer: &mut [u8]) -> Result<usize, crate::Error<D::Error>> {
         self.volume_mgr.read(self.raw_file, buffer)
     }
 
     /// Write to the file
-    pub fn write(&mut self, buffer: &[u8]) -> Result<(), crate::Error<D::Error>> {
+    pub fn write(&self, buffer: &[u8]) -> Result<(), crate::Error<D::Error>> {
         self.volume_mgr.write(self.raw_file, buffer)
     }
 
@@ -93,18 +93,18 @@ where
     }
 
     /// Seek a file with an offset from the current position.
-    pub fn seek_from_current(&mut self, offset: i32) -> Result<(), crate::Error<D::Error>> {
+    pub fn seek_from_current(&self, offset: i32) -> Result<(), crate::Error<D::Error>> {
         self.volume_mgr
             .file_seek_from_current(self.raw_file, offset)
     }
 
     /// Seek a file with an offset from the start of the file.
-    pub fn seek_from_start(&mut self, offset: u32) -> Result<(), crate::Error<D::Error>> {
+    pub fn seek_from_start(&self, offset: u32) -> Result<(), crate::Error<D::Error>> {
         self.volume_mgr.file_seek_from_start(self.raw_file, offset)
     }
 
     /// Seek a file with an offset back from the end of the file.
-    pub fn seek_from_end(&mut self, offset: u32) -> Result<(), crate::Error<D::Error>> {
+    pub fn seek_from_end(&self, offset: u32) -> Result<(), crate::Error<D::Error>> {
         self.volume_mgr.file_seek_from_end(self.raw_file, offset)
     }
 
@@ -130,7 +130,7 @@ where
     }
 
     /// Flush any written data by updating the directory entry.
-    pub fn flush(&mut self) -> Result<(), Error<D::Error>> {
+    pub fn flush(&self) -> Result<(), Error<D::Error>> {
         self.volume_mgr.flush_file(self.raw_file)
     }
 
@@ -213,7 +213,7 @@ impl<
     }
 
     fn flush(&mut self) -> Result<(), Self::Error> {
-        self.flush()
+        Self::flush(self)
     }
 }
 

--- a/src/filesystem/mod.rs
+++ b/src/filesystem/mod.rs
@@ -4,7 +4,7 @@
 //! most (if not all) supported filesystems.
 
 /// Maximum file size supported by this library
-pub const MAX_FILE_SIZE: u32 = core::u32::MAX;
+pub const MAX_FILE_SIZE: u32 = u32::MAX;
 
 mod attributes;
 mod cluster;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,8 @@ where
     DirAlreadyExists,
     /// The filesystem tried to gain a lock whilst already locked.
     ///
-    /// This is a bug in the filesystem. Please open an issue.
+    /// This is either a bug in the filesystem, or you tried to access the
+    /// filesystem API from inside a directory iterator (that isn't allowed).
     LockError,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,10 @@ where
     DiskFull,
     /// A directory with that name already exists
     DirAlreadyExists,
+    /// The filesystem tried to gain a lock whilst already locked.
+    ///
+    /// This is a bug in the filesystem. Please open an issue.
+    LockError,
 }
 
 impl<E: Debug> embedded_io::Error for Error<E> {
@@ -216,7 +220,8 @@ impl<E: Debug> embedded_io::Error for Error<E> {
             | Error::EndOfFile
             | Error::DiskFull
             | Error::NotEnoughSpace
-            | Error::AllocationError => ErrorKind::Other,
+            | Error::AllocationError
+            | Error::LockError => ErrorKind::Other,
             Error::NoSuchVolume
             | Error::FilenameError(_)
             | Error::BadHandle

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,10 @@
 //! {
 //!     let sdcard = SdCard::new(spi, delay);
 //!     println!("Card size is {} bytes", sdcard.num_bytes()?);
-//!     let mut volume_mgr = VolumeManager::new(sdcard, ts);
-//!     let mut volume0 = volume_mgr.open_volume(VolumeIdx(0))?;
+//!     let volume_mgr = VolumeManager::new(sdcard, ts);
+//!     let volume0 = volume_mgr.open_volume(VolumeIdx(0))?;
 //!     println!("Volume 0: {:?}", volume0);
-//!     let mut root_dir = volume0.open_root_dir()?;
+//!     let root_dir = volume0.open_root_dir()?;
 //!     let mut my_file = root_dir.open_file_in_dir("MY_FILE.TXT", Mode::ReadOnly)?;
 //!     while !my_file.is_eof() {
 //!         let mut buffer = [0u8; 32];
@@ -47,8 +47,8 @@
 //!
 //! * `log`: Enabled by default. Generates log messages using the `log` crate.
 //! * `defmt-log`: By turning off the default features and enabling the
-//! `defmt-log` feature you can configure this crate to log messages over defmt
-//! instead.
+//!   `defmt-log` feature you can configure this crate to log messages over defmt
+//!   instead.
 //!
 //! You cannot enable both the `log` feature and the `defmt-log` feature.
 
@@ -271,7 +271,7 @@ impl RawVolume {
         const MAX_VOLUMES: usize,
     >(
         self,
-        volume_mgr: &mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+        volume_mgr: &VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
     ) -> Volume<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
     where
         D: crate::BlockDevice,
@@ -295,7 +295,7 @@ where
     T: crate::TimeSource,
 {
     raw_volume: RawVolume,
-    volume_mgr: &'a mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+    volume_mgr: &'a VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
 }
 
 impl<'a, D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
@@ -307,7 +307,7 @@ where
     /// Create a new `Volume` from a `RawVolume`
     pub fn new(
         raw_volume: RawVolume,
-        volume_mgr: &'a mut VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
+        volume_mgr: &'a VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
     ) -> Volume<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES> {
         Volume {
             raw_volume,
@@ -320,7 +320,7 @@ where
     /// You can then read the directory entries with `iterate_dir`, or you can
     /// use `open_file_in_dir`.
     pub fn open_root_dir(
-        &mut self,
+        &self,
     ) -> Result<crate::Directory<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>> {
         let d = self.volume_mgr.open_root_dir(self.raw_volume)?;
         Ok(d.to_directory(self.volume_mgr))

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -377,6 +377,14 @@ where
     }
 
     /// Call a callback function for each directory entry in a directory.
+    ///
+    /// <div class="warning">
+    ///
+    /// Do not attempt to call any methods on the VolumeManager or any of its
+    /// handles from inside the callback. You will get a lock error because the
+    /// object is already locked in order to do the iteration.
+    ///
+    /// </div>
     pub fn iterate_dir<F>(&self, directory: RawDirectory, func: F) -> Result<(), Error<D::Error>>
     where
         F: FnMut(&DirEntry),

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -264,8 +264,9 @@ where
         let short_file_name = name.to_short_filename().map_err(Error::FilenameError)?;
 
         // Open the directory
+
+        // Should we short-cut? (root dir doesn't have ".")
         if short_file_name == ShortFileName::this_dir() {
-            // short-cut (root dir doesn't have ".")
             let directory_id = RawDirectory(data.id_generator.generate());
             let dir_info = DirectoryInfo {
                 raw_directory: directory_id,
@@ -279,6 +280,8 @@ where
 
             return Ok(directory_id);
         }
+
+        // ok we'll actually look for the directory then
 
         let dir_entry = match &data.open_volumes[volume_idx].volume_type {
             VolumeType::Fat(fat) => fat.find_directory_entry(

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -2,6 +2,7 @@
 //!
 //! The volume manager handles partitions and open files on a block device.
 
+use core::cell::RefCell;
 use core::convert::TryFrom;
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -38,10 +39,7 @@ pub struct VolumeManager<
 {
     pub(crate) block_device: D,
     pub(crate) time_source: T,
-    id_generator: HandleGenerator,
-    open_volumes: Vec<VolumeInfo, MAX_VOLUMES>,
-    open_dirs: Vec<DirectoryInfo, MAX_DIRS>,
-    open_files: Vec<FileInfo, MAX_FILES>,
+    data: RefCell<VolumeManagerData<MAX_DIRS, MAX_FILES, MAX_VOLUMES>>,
 }
 
 impl<D, T> VolumeManager<D, T, 4, 4>
@@ -87,15 +85,22 @@ where
         VolumeManager {
             block_device,
             time_source,
-            id_generator: HandleGenerator::new(id_offset),
-            open_volumes: Vec::new(),
-            open_dirs: Vec::new(),
-            open_files: Vec::new(),
+            data: RefCell::new(VolumeManagerData {
+                id_generator: HandleGenerator::new(id_offset),
+                open_volumes: Vec::new(),
+                open_dirs: Vec::new(),
+                open_files: Vec::new(),
+            }),
         }
     }
 
     /// Temporarily get access to the underlying block device.
-    pub fn device(&mut self) -> &mut D {
+    pub fn device(&self) -> &D {
+        &self.block_device
+    }
+
+    /// Temporarily get access to the underlying block device.
+    pub fn device_mut(&mut self) -> &mut D {
         &mut self.block_device
     }
 
@@ -104,7 +109,7 @@ where
     /// We do not support GUID Partition Table disks. Nor do we support any
     /// concept of drive letters - that is for a higher layer to handle.
     pub fn open_volume(
-        &mut self,
+        &self,
         volume_idx: VolumeIdx,
     ) -> Result<Volume<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>> {
         let v = self.open_raw_volume(volume_idx)?;
@@ -118,7 +123,7 @@ where
     ///
     /// This function gives you a `RawVolume` and you must close the volume by
     /// calling `VolumeManager::close_volume`.
-    pub fn open_raw_volume(&mut self, volume_idx: VolumeIdx) -> Result<RawVolume, Error<D::Error>> {
+    pub fn open_raw_volume(&self, volume_idx: VolumeIdx) -> Result<RawVolume, Error<D::Error>> {
         const PARTITION1_START: usize = 446;
         const PARTITION2_START: usize = PARTITION1_START + PARTITION_INFO_LENGTH;
         const PARTITION3_START: usize = PARTITION2_START + PARTITION_INFO_LENGTH;
@@ -131,11 +136,13 @@ where
         const PARTITION_INFO_LBA_START_INDEX: usize = 8;
         const PARTITION_INFO_NUM_BLOCKS_INDEX: usize = 12;
 
-        if self.open_volumes.is_full() {
+        let mut data = self.data.borrow_mut();
+
+        if data.open_volumes.is_full() {
             return Err(Error::TooManyOpenVolumes);
         }
 
-        for v in self.open_volumes.iter() {
+        for v in data.open_volumes.iter() {
             if v.idx == volume_idx {
                 return Err(Error::VolumeAlreadyOpen);
             }
@@ -192,14 +199,14 @@ where
             | PARTITION_ID_FAT16_LBA
             | PARTITION_ID_FAT16 => {
                 let volume = fat::parse_volume(&self.block_device, lba_start, num_blocks)?;
-                let id = RawVolume(self.id_generator.generate());
+                let id = RawVolume(data.id_generator.generate());
                 let info = VolumeInfo {
                     raw_volume: id,
                     idx: volume_idx,
                     volume_type: volume,
                 };
                 // We already checked for space
-                self.open_volumes.push(info).unwrap();
+                data.open_volumes.push(info).unwrap();
                 Ok(id)
             }
             _ => Err(Error::FormatError("Partition type not supported")),
@@ -210,17 +217,19 @@ where
     ///
     /// You can then read the directory entries with `iterate_dir`, or you can
     /// use `open_file_in_dir`.
-    pub fn open_root_dir(&mut self, volume: RawVolume) -> Result<RawDirectory, Error<D::Error>> {
+    pub fn open_root_dir(&self, volume: RawVolume) -> Result<RawDirectory, Error<D::Error>> {
         // Opening a root directory twice is OK
 
-        let directory_id = RawDirectory(self.id_generator.generate());
+        let mut data = self.data.borrow_mut();
+
+        let directory_id = RawDirectory(data.id_generator.generate());
         let dir_info = DirectoryInfo {
-            volume_id: volume,
+            raw_volume: volume,
             cluster: ClusterId::ROOT_DIR,
-            directory_id,
+            raw_directory: directory_id,
         };
 
-        self.open_dirs
+        data.open_dirs
             .push(dir_info)
             .map_err(|_| Error::TooManyOpenDirs)?;
 
@@ -233,44 +242,47 @@ where
     ///
     /// Passing "." as the name results in opening the `parent_dir` a second time.
     pub fn open_dir<N>(
-        &mut self,
+        &self,
         parent_dir: RawDirectory,
         name: N,
     ) -> Result<RawDirectory, Error<D::Error>>
     where
         N: ToShortFileName,
     {
-        if self.open_dirs.is_full() {
+        let mut data = self.data.borrow_mut();
+
+        if data.open_dirs.is_full() {
             return Err(Error::TooManyOpenDirs);
         }
 
         // Find dir by ID
-        let parent_dir_idx = self.get_dir_by_id(parent_dir)?;
-        let volume_idx = self.get_volume_by_id(self.open_dirs[parent_dir_idx].volume_id)?;
+        let parent_dir_idx = data.get_dir_by_id(parent_dir)?;
+        let volume_idx = data.get_volume_by_id(data.open_dirs[parent_dir_idx].raw_volume)?;
         let short_file_name = name.to_short_filename().map_err(Error::FilenameError)?;
-        let parent_dir_info = &self.open_dirs[parent_dir_idx];
 
         // Open the directory
         if short_file_name == ShortFileName::this_dir() {
             // short-cut (root dir doesn't have ".")
-            let directory_id = RawDirectory(self.id_generator.generate());
+            let directory_id = RawDirectory(data.id_generator.generate());
             let dir_info = DirectoryInfo {
-                directory_id,
-                volume_id: self.open_volumes[volume_idx].raw_volume,
-                cluster: parent_dir_info.cluster,
+                raw_directory: directory_id,
+                raw_volume: data.open_volumes[volume_idx].raw_volume,
+                cluster: data.open_dirs[parent_dir_idx].cluster,
             };
 
-            self.open_dirs
+            data.open_dirs
                 .push(dir_info)
                 .map_err(|_| Error::TooManyOpenDirs)?;
 
             return Ok(directory_id);
         }
 
-        let dir_entry = match &self.open_volumes[volume_idx].volume_type {
-            VolumeType::Fat(fat) => {
-                fat.find_directory_entry(&self.block_device, parent_dir_info, &short_file_name)?
-            }
+        let dir_entry = match &data.open_volumes[volume_idx].volume_type {
+            VolumeType::Fat(fat) => fat.find_directory_entry(
+                &self.block_device,
+                &data.open_dirs[parent_dir_idx],
+                &short_file_name,
+            )?,
         };
 
         debug!("Found dir entry: {:?}", dir_entry);
@@ -283,14 +295,14 @@ where
         // no cached state and so opening a directory twice is allowable.
 
         // Remember this open directory.
-        let directory_id = RawDirectory(self.id_generator.generate());
+        let directory_id = RawDirectory(data.id_generator.generate());
         let dir_info = DirectoryInfo {
-            directory_id,
-            volume_id: self.open_volumes[volume_idx].raw_volume,
+            raw_directory: directory_id,
+            raw_volume: data.open_volumes[volume_idx].raw_volume,
             cluster: dir_entry.cluster,
         };
 
-        self.open_dirs
+        data.open_dirs
             .push(dir_info)
             .map_err(|_| Error::TooManyOpenDirs)?;
 
@@ -299,10 +311,12 @@ where
 
     /// Close a directory. You cannot perform operations on an open directory
     /// and so must close it if you want to do something with it.
-    pub fn close_dir(&mut self, directory: RawDirectory) -> Result<(), Error<D::Error>> {
-        for (idx, info) in self.open_dirs.iter().enumerate() {
-            if directory == info.directory_id {
-                self.open_dirs.swap_remove(idx);
+    pub fn close_dir(&self, directory: RawDirectory) -> Result<(), Error<D::Error>> {
+        let mut data = self.data.borrow_mut();
+
+        for (idx, info) in data.open_dirs.iter().enumerate() {
+            if directory == info.raw_directory {
+                data.open_dirs.swap_remove(idx);
                 return Ok(());
             }
         }
@@ -312,159 +326,68 @@ where
     /// Close a volume
     ///
     /// You can't close it if there are any files or directories open on it.
-    pub fn close_volume(&mut self, volume: RawVolume) -> Result<(), Error<D::Error>> {
-        for f in self.open_files.iter() {
+    pub fn close_volume(&self, volume: RawVolume) -> Result<(), Error<D::Error>> {
+        let mut data = self.data.borrow_mut();
+
+        for f in data.open_files.iter() {
             if f.raw_volume == volume {
                 return Err(Error::VolumeStillInUse);
             }
         }
 
-        for d in self.open_dirs.iter() {
-            if d.volume_id == volume {
+        for d in data.open_dirs.iter() {
+            if d.raw_volume == volume {
                 return Err(Error::VolumeStillInUse);
             }
         }
 
-        let volume_idx = self.get_volume_by_id(volume)?;
-        self.open_volumes.swap_remove(volume_idx);
+        let volume_idx = data.get_volume_by_id(volume)?;
+
+        data.open_volumes.swap_remove(volume_idx);
 
         Ok(())
     }
 
     /// Look in a directory for a named file.
     pub fn find_directory_entry<N>(
-        &mut self,
+        &self,
         directory: RawDirectory,
         name: N,
     ) -> Result<DirEntry, Error<D::Error>>
     where
         N: ToShortFileName,
     {
-        let directory_idx = self.get_dir_by_id(directory)?;
-        let volume_idx = self.get_volume_by_id(self.open_dirs[directory_idx].volume_id)?;
-        match &self.open_volumes[volume_idx].volume_type {
+        let data = self.data.borrow();
+
+        let directory_idx = data.get_dir_by_id(directory)?;
+        let volume_idx = data.get_volume_by_id(data.open_dirs[directory_idx].raw_volume)?;
+        match &data.open_volumes[volume_idx].volume_type {
             VolumeType::Fat(fat) => {
                 let sfn = name.to_short_filename().map_err(Error::FilenameError)?;
-                fat.find_directory_entry(&self.block_device, &self.open_dirs[directory_idx], &sfn)
+                fat.find_directory_entry(&self.block_device, &data.open_dirs[directory_idx], &sfn)
             }
         }
     }
 
     /// Call a callback function for each directory entry in a directory.
-    pub fn iterate_dir<F>(
-        &mut self,
-        directory: RawDirectory,
-        func: F,
-    ) -> Result<(), Error<D::Error>>
+    pub fn iterate_dir<F>(&self, directory: RawDirectory, func: F) -> Result<(), Error<D::Error>>
     where
         F: FnMut(&DirEntry),
     {
-        let directory_idx = self.get_dir_by_id(directory)?;
-        let volume_idx = self.get_volume_by_id(self.open_dirs[directory_idx].volume_id)?;
-        match &self.open_volumes[volume_idx].volume_type {
+        let data = self.data.borrow();
+
+        let directory_idx = data.get_dir_by_id(directory)?;
+        let volume_idx = data.get_volume_by_id(data.open_dirs[directory_idx].raw_volume)?;
+        match &data.open_volumes[volume_idx].volume_type {
             VolumeType::Fat(fat) => {
-                fat.iterate_dir(&self.block_device, &self.open_dirs[directory_idx], func)
+                fat.iterate_dir(&self.block_device, &data.open_dirs[directory_idx], func)
             }
         }
-    }
-
-    /// Open a file from a DirEntry. This is obtained by calling iterate_dir.
-    ///
-    /// # Safety
-    ///
-    /// The DirEntry must be a valid DirEntry read from disk, and not just
-    /// random numbers.
-    unsafe fn open_dir_entry(
-        &mut self,
-        volume: RawVolume,
-        dir_entry: DirEntry,
-        mode: Mode,
-    ) -> Result<RawFile, Error<D::Error>> {
-        // This check is load-bearing - we do an unchecked push later.
-        if self.open_files.is_full() {
-            return Err(Error::TooManyOpenFiles);
-        }
-
-        if dir_entry.attributes.is_read_only() && mode != Mode::ReadOnly {
-            return Err(Error::ReadOnly);
-        }
-
-        if dir_entry.attributes.is_directory() {
-            return Err(Error::OpenedDirAsFile);
-        }
-
-        // Check it's not already open
-        if self.file_is_open(volume, &dir_entry) {
-            return Err(Error::FileAlreadyOpen);
-        }
-
-        let mode = solve_mode_variant(mode, true);
-        let file_id = RawFile(self.id_generator.generate());
-
-        let file = match mode {
-            Mode::ReadOnly => FileInfo {
-                raw_file: file_id,
-                raw_volume: volume,
-                current_cluster: (0, dir_entry.cluster),
-                current_offset: 0,
-                mode,
-                entry: dir_entry,
-                dirty: false,
-            },
-            Mode::ReadWriteAppend => {
-                let mut file = FileInfo {
-                    raw_file: file_id,
-                    raw_volume: volume,
-                    current_cluster: (0, dir_entry.cluster),
-                    current_offset: 0,
-                    mode,
-                    entry: dir_entry,
-                    dirty: false,
-                };
-                // seek_from_end with 0 can't fail
-                file.seek_from_end(0).ok();
-                file
-            }
-            Mode::ReadWriteTruncate => {
-                let mut file = FileInfo {
-                    raw_file: file_id,
-                    raw_volume: volume,
-                    current_cluster: (0, dir_entry.cluster),
-                    current_offset: 0,
-                    mode,
-                    entry: dir_entry,
-                    dirty: false,
-                };
-                let volume_idx = self.get_volume_by_id(volume)?;
-                match &mut self.open_volumes[volume_idx].volume_type {
-                    VolumeType::Fat(fat) => {
-                        fat.truncate_cluster_chain(&self.block_device, file.entry.cluster)?
-                    }
-                };
-                file.update_length(0);
-                match &self.open_volumes[volume_idx].volume_type {
-                    VolumeType::Fat(fat) => {
-                        file.entry.mtime = self.time_source.get_timestamp();
-                        fat.write_entry_to_disk(&self.block_device, &file.entry)?;
-                    }
-                };
-
-                file
-            }
-            _ => return Err(Error::Unsupported),
-        };
-
-        // Remember this open file - can't be full as we checked already
-        unsafe {
-            self.open_files.push_unchecked(file);
-        }
-
-        Ok(file_id)
     }
 
     /// Open a file with the given full path. A file can only be opened once.
     pub fn open_file_in_dir<N>(
-        &mut self,
+        &self,
         directory: RawDirectory,
         name: N,
         mode: Mode,
@@ -472,21 +395,22 @@ where
     where
         N: ToShortFileName,
     {
+        let mut data = self.data.borrow_mut();
+
         // This check is load-bearing - we do an unchecked push later.
-        if self.open_files.is_full() {
+        if data.open_files.is_full() {
             return Err(Error::TooManyOpenFiles);
         }
 
-        let directory_idx = self.get_dir_by_id(directory)?;
-        let directory_info = &self.open_dirs[directory_idx];
-        let volume_id = self.open_dirs[directory_idx].volume_id;
-        let volume_idx = self.get_volume_by_id(volume_id)?;
-        let volume_info = &self.open_volumes[volume_idx];
+        let directory_idx = data.get_dir_by_id(directory)?;
+        let volume_id = data.open_dirs[directory_idx].raw_volume;
+        let volume_idx = data.get_volume_by_id(volume_id)?;
+        let volume_info = &data.open_volumes[volume_idx];
         let sfn = name.to_short_filename().map_err(Error::FilenameError)?;
 
         let dir_entry = match &volume_info.volume_type {
             VolumeType::Fat(fat) => {
-                fat.find_directory_entry(&self.block_device, directory_info, &sfn)
+                fat.find_directory_entry(&self.block_device, &data.open_dirs[directory_idx], &sfn)
             }
         };
 
@@ -512,7 +436,7 @@ where
 
         // Check if it's open already
         if let Some(dir_entry) = &dir_entry {
-            if self.file_is_open(volume_info.raw_volume, dir_entry) {
+            if data.file_is_open(volume_info.raw_volume, dir_entry) {
                 return Err(Error::FileAlreadyOpen);
             }
         }
@@ -524,19 +448,20 @@ where
                 if dir_entry.is_some() {
                     return Err(Error::FileAlreadyExists);
                 }
+                let cluster = data.open_dirs[directory_idx].cluster;
                 let att = Attributes::create_from_fat(0);
-                let volume_idx = self.get_volume_by_id(volume_id)?;
-                let entry = match &mut self.open_volumes[volume_idx].volume_type {
+                let volume_idx = data.get_volume_by_id(volume_id)?;
+                let entry = match &mut data.open_volumes[volume_idx].volume_type {
                     VolumeType::Fat(fat) => fat.write_new_directory_entry(
                         &self.block_device,
                         &self.time_source,
-                        directory_info.cluster,
+                        cluster,
                         sfn,
                         att,
                     )?,
                 };
 
-                let file_id = RawFile(self.id_generator.generate());
+                let file_id = RawFile(data.id_generator.generate());
 
                 let file = FileInfo {
                     raw_file: file_id,
@@ -550,7 +475,7 @@ where
 
                 // Remember this open file - can't be full as we checked already
                 unsafe {
-                    self.open_files.push_unchecked(file);
+                    data.open_files.push_unchecked(file);
                 }
 
                 Ok(file_id)
@@ -558,27 +483,102 @@ where
             _ => {
                 // Safe to unwrap, since we actually have an entry if we got here
                 let dir_entry = dir_entry.unwrap();
-                // Safety: We read this dir entry off disk and didn't change it
-                unsafe { self.open_dir_entry(volume_id, dir_entry, mode) }
+
+                if dir_entry.attributes.is_read_only() && mode != Mode::ReadOnly {
+                    return Err(Error::ReadOnly);
+                }
+
+                if dir_entry.attributes.is_directory() {
+                    return Err(Error::OpenedDirAsFile);
+                }
+
+                // Check it's not already open
+                if data.file_is_open(volume_id, &dir_entry) {
+                    return Err(Error::FileAlreadyOpen);
+                }
+
+                let mode = solve_mode_variant(mode, true);
+                let raw_file = RawFile(data.id_generator.generate());
+
+                let file = match mode {
+                    Mode::ReadOnly => FileInfo {
+                        raw_file,
+                        raw_volume: volume_id,
+                        current_cluster: (0, dir_entry.cluster),
+                        current_offset: 0,
+                        mode,
+                        entry: dir_entry,
+                        dirty: false,
+                    },
+                    Mode::ReadWriteAppend => {
+                        let mut file = FileInfo {
+                            raw_file,
+                            raw_volume: volume_id,
+                            current_cluster: (0, dir_entry.cluster),
+                            current_offset: 0,
+                            mode,
+                            entry: dir_entry,
+                            dirty: false,
+                        };
+                        // seek_from_end with 0 can't fail
+                        file.seek_from_end(0).ok();
+                        file
+                    }
+                    Mode::ReadWriteTruncate => {
+                        let mut file = FileInfo {
+                            raw_file,
+                            raw_volume: volume_id,
+                            current_cluster: (0, dir_entry.cluster),
+                            current_offset: 0,
+                            mode,
+                            entry: dir_entry,
+                            dirty: false,
+                        };
+                        match &mut data.open_volumes[volume_idx].volume_type {
+                            VolumeType::Fat(fat) => {
+                                fat.truncate_cluster_chain(&self.block_device, file.entry.cluster)?
+                            }
+                        };
+                        file.update_length(0);
+                        match &data.open_volumes[volume_idx].volume_type {
+                            VolumeType::Fat(fat) => {
+                                file.entry.mtime = self.time_source.get_timestamp();
+                                fat.write_entry_to_disk(&self.block_device, &file.entry)?;
+                            }
+                        };
+
+                        file
+                    }
+                    _ => return Err(Error::Unsupported),
+                };
+
+                // Remember this open file - can't be full as we checked already
+                unsafe {
+                    data.open_files.push_unchecked(file);
+                }
+
+                Ok(raw_file)
             }
         }
     }
 
     /// Delete a closed file with the given filename, if it exists.
     pub fn delete_file_in_dir<N>(
-        &mut self,
+        &self,
         directory: RawDirectory,
         name: N,
     ) -> Result<(), Error<D::Error>>
     where
         N: ToShortFileName,
     {
-        let dir_idx = self.get_dir_by_id(directory)?;
-        let dir_info = &self.open_dirs[dir_idx];
-        let volume_idx = self.get_volume_by_id(dir_info.volume_id)?;
+        let data = self.data.borrow();
+
+        let dir_idx = data.get_dir_by_id(directory)?;
+        let dir_info = &data.open_dirs[dir_idx];
+        let volume_idx = data.get_volume_by_id(dir_info.raw_volume)?;
         let sfn = name.to_short_filename().map_err(Error::FilenameError)?;
 
-        let dir_entry = match &self.open_volumes[volume_idx].volume_type {
+        let dir_entry = match &data.open_volumes[volume_idx].volume_type {
             VolumeType::Fat(fat) => fat.find_directory_entry(&self.block_device, dir_info, &sfn),
         }?;
 
@@ -586,12 +586,12 @@ where
             return Err(Error::DeleteDirAsFile);
         }
 
-        if self.file_is_open(dir_info.volume_id, &dir_entry) {
+        if data.file_is_open(dir_info.raw_volume, &dir_entry) {
             return Err(Error::FileAlreadyOpen);
         }
 
-        let volume_idx = self.get_volume_by_id(dir_info.volume_id)?;
-        match &self.open_volumes[volume_idx].volume_type {
+        let volume_idx = data.get_volume_by_id(dir_info.raw_volume)?;
+        match &data.open_volumes[volume_idx].volume_type {
             VolumeType::Fat(fat) => {
                 fat.delete_directory_entry(&self.block_device, dir_info, &sfn)?
             }
@@ -602,64 +602,51 @@ where
 
     /// Search the root directory for a volume label
     pub fn get_root_volume_label(
-        &mut self,
+        &self,
         volume: RawVolume,
     ) -> Result<Option<crate::VolumeName>, Error<D::Error>> {
         let directory = self.open_root_dir(volume)?;
+        let data = self.data.borrow();
         // this can't fail - we literally just opened it
-        let inner = || -> Result<Option<crate::VolumeName>, Error<D::Error>> {
-            let directory_idx = self.get_dir_by_id(directory).expect("Dir ID error");
-            let volume_idx = self.get_volume_by_id(self.open_dirs[directory_idx].volume_id)?;
-            let mut maybe_volume_name = None;
-            match &self.open_volumes[volume_idx].volume_type {
-                VolumeType::Fat(fat) => {
-                    fat.iterate_dir(&self.block_device, &self.open_dirs[directory_idx], |de| {
-                        if de.attributes == Attributes::create_from_fat(Attributes::VOLUME) {
-                            maybe_volume_name = Some(unsafe { de.name.clone().to_volume_label() })
-                        }
-                    })?;
-                }
-            }
-            Ok(maybe_volume_name)
-        };
-        let result = inner();
-        self.close_dir(directory)?;
-        result
-    }
-
-    /// Check if a file is open
-    ///
-    /// Returns `true` if it's open, `false`, otherwise.
-    fn file_is_open(&self, volume: RawVolume, dir_entry: &DirEntry) -> bool {
-        for f in self.open_files.iter() {
-            if f.raw_volume == volume
-                && f.entry.entry_block == dir_entry.entry_block
-                && f.entry.entry_offset == dir_entry.entry_offset
-            {
-                return true;
+        let directory_idx = data
+            .get_dir_by_id::<D::Error>(directory)
+            .expect("Dir ID error");
+        let volume_idx = data.get_volume_by_id(data.open_dirs[directory_idx].raw_volume)?;
+        let mut maybe_volume_name = None;
+        match &data.open_volumes[volume_idx].volume_type {
+            VolumeType::Fat(fat) => {
+                fat.iterate_dir(&self.block_device, &data.open_dirs[directory_idx], |de| {
+                    if de.attributes == Attributes::create_from_fat(Attributes::VOLUME) {
+                        maybe_volume_name = Some(unsafe { de.name.clone().to_volume_label() })
+                    }
+                })?;
             }
         }
-        false
+        Ok(maybe_volume_name)
     }
 
     /// Read from an open file.
-    pub fn read(&mut self, file: RawFile, buffer: &mut [u8]) -> Result<usize, Error<D::Error>> {
-        let file_idx = self.get_file_by_id(file)?;
-        let volume_idx = self.get_volume_by_id(self.open_files[file_idx].raw_volume)?;
+    pub fn read(&self, file: RawFile, buffer: &mut [u8]) -> Result<usize, Error<D::Error>> {
+        let mut data = self.data.borrow_mut();
+
+        let file_idx = data.get_file_by_id(file)?;
+        let volume_idx = data.get_volume_by_id(data.open_files[file_idx].raw_volume)?;
+
         // Calculate which file block the current offset lies within
         // While there is more to read, read the block and copy in to the buffer.
         // If we need to find the next cluster, walk the FAT.
         let mut space = buffer.len();
         let mut read = 0;
-        while space > 0 && !self.open_files[file_idx].eof() {
-            let mut current_cluster = self.open_files[file_idx].current_cluster;
-            let (block_idx, block_offset, block_avail) = self.find_data_on_disk(
+        while space > 0 && !data.open_files[file_idx].eof() {
+            let mut current_cluster = data.open_files[file_idx].current_cluster;
+            let (block_idx, block_offset, block_avail) = data.find_data_on_disk(
+                &self.block_device,
                 volume_idx,
                 &mut current_cluster,
-                self.open_files[file_idx].entry.cluster,
-                self.open_files[file_idx].current_offset,
+                data.open_files[file_idx].entry.cluster,
+                data.open_files[file_idx].current_offset,
             )?;
-            self.open_files[file_idx].current_cluster = current_cluster;
+            data.open_files[file_idx].current_cluster = current_cluster;
             let mut blocks = [Block::new()];
             trace!("Reading file ID {:?}", file);
             self.block_device
@@ -668,13 +655,13 @@ where
             let block = &blocks[0];
             let to_copy = block_avail
                 .min(space)
-                .min(self.open_files[file_idx].left() as usize);
+                .min(data.open_files[file_idx].left() as usize);
             assert!(to_copy != 0);
             buffer[read..read + to_copy]
                 .copy_from_slice(&block[block_offset..block_offset + to_copy]);
             read += to_copy;
             space -= to_copy;
-            self.open_files[file_idx]
+            data.open_files[file_idx]
                 .seek_from_current(to_copy as i32)
                 .unwrap();
         }
@@ -682,63 +669,66 @@ where
     }
 
     /// Write to a open file.
-    pub fn write(&mut self, file: RawFile, buffer: &[u8]) -> Result<(), Error<D::Error>> {
+    pub fn write(&self, file: RawFile, buffer: &[u8]) -> Result<(), Error<D::Error>> {
         #[cfg(feature = "defmt-log")]
         debug!("write(file={:?}, buffer={:x}", file, buffer);
 
         #[cfg(feature = "log")]
         debug!("write(file={:?}, buffer={:x?}", file, buffer);
 
+        let mut data = self.data.borrow_mut();
+
         // Clone this so we can touch our other structures. Need to ensure we
         // write it back at the end.
-        let file_idx = self.get_file_by_id(file)?;
-        let volume_idx = self.get_volume_by_id(self.open_files[file_idx].raw_volume)?;
+        let file_idx = data.get_file_by_id(file)?;
+        let volume_idx = data.get_volume_by_id(data.open_files[file_idx].raw_volume)?;
 
-        if self.open_files[file_idx].mode == Mode::ReadOnly {
+        if data.open_files[file_idx].mode == Mode::ReadOnly {
             return Err(Error::ReadOnly);
         }
 
-        self.open_files[file_idx].dirty = true;
+        data.open_files[file_idx].dirty = true;
 
-        if self.open_files[file_idx].entry.cluster.0 < RESERVED_ENTRIES {
+        if data.open_files[file_idx].entry.cluster.0 < RESERVED_ENTRIES {
             // file doesn't have a valid allocated cluster (possible zero-length file), allocate one
-            self.open_files[file_idx].entry.cluster =
-                match self.open_volumes[volume_idx].volume_type {
+            data.open_files[file_idx].entry.cluster =
+                match data.open_volumes[volume_idx].volume_type {
                     VolumeType::Fat(ref mut fat) => {
                         fat.alloc_cluster(&self.block_device, None, false)?
                     }
                 };
             debug!(
                 "Alloc first cluster {:?}",
-                self.open_files[file_idx].entry.cluster
+                data.open_files[file_idx].entry.cluster
             );
         }
 
         // Clone this so we can touch our other structures.
-        let volume_idx = self.get_volume_by_id(self.open_files[file_idx].raw_volume)?;
+        let volume_idx = data.get_volume_by_id(data.open_files[file_idx].raw_volume)?;
 
-        if (self.open_files[file_idx].current_cluster.1) < self.open_files[file_idx].entry.cluster {
+        if (data.open_files[file_idx].current_cluster.1) < data.open_files[file_idx].entry.cluster {
             debug!("Rewinding to start");
-            self.open_files[file_idx].current_cluster =
-                (0, self.open_files[file_idx].entry.cluster);
+            data.open_files[file_idx].current_cluster =
+                (0, data.open_files[file_idx].entry.cluster);
         }
         let bytes_until_max =
-            usize::try_from(MAX_FILE_SIZE - self.open_files[file_idx].current_offset)
+            usize::try_from(MAX_FILE_SIZE - data.open_files[file_idx].current_offset)
                 .map_err(|_| Error::ConversionError)?;
         let bytes_to_write = core::cmp::min(buffer.len(), bytes_until_max);
         let mut written = 0;
 
         while written < bytes_to_write {
-            let mut current_cluster = self.open_files[file_idx].current_cluster;
+            let mut current_cluster = data.open_files[file_idx].current_cluster;
             debug!(
                 "Have written bytes {}/{}, finding cluster {:?}",
                 written, bytes_to_write, current_cluster
             );
-            let current_offset = self.open_files[file_idx].current_offset;
-            let (block_idx, block_offset, block_avail) = match self.find_data_on_disk(
+            let current_offset = data.open_files[file_idx].current_offset;
+            let (block_idx, block_offset, block_avail) = match data.find_data_on_disk(
+                &self.block_device,
                 volume_idx,
                 &mut current_cluster,
-                self.open_files[file_idx].entry.cluster,
+                data.open_files[file_idx].entry.cluster,
                 current_offset,
             ) {
                 Ok(vars) => {
@@ -750,7 +740,7 @@ where
                 }
                 Err(Error::EndOfFile) => {
                     debug!("Extending file");
-                    match self.open_volumes[volume_idx].volume_type {
+                    match data.open_volumes[volume_idx].volume_type {
                         VolumeType::Fat(ref mut fat) => {
                             if fat
                                 .alloc_cluster(&self.block_device, Some(current_cluster.1), false)
@@ -759,12 +749,13 @@ where
                                 return Err(Error::DiskFull);
                             }
                             debug!("Allocated new FAT cluster, finding offsets...");
-                            let new_offset = self
+                            let new_offset = data
                                 .find_data_on_disk(
+                                    &self.block_device,
                                     volume_idx,
                                     &mut current_cluster,
-                                    self.open_files[file_idx].entry.cluster,
-                                    self.open_files[file_idx].current_offset,
+                                    data.open_files[file_idx].entry.cluster,
+                                    data.open_files[file_idx].current_offset,
                                 )
                                 .map_err(|_| Error::AllocationError)?;
                             debug!("New offset {:?}", new_offset);
@@ -790,52 +781,53 @@ where
                 .write(&blocks, block_idx)
                 .map_err(Error::DeviceError)?;
             written += to_copy;
-            self.open_files[file_idx].current_cluster = current_cluster;
+            data.open_files[file_idx].current_cluster = current_cluster;
 
             let to_copy = to_copy as u32;
-            let new_offset = self.open_files[file_idx].current_offset + to_copy;
-            if new_offset > self.open_files[file_idx].entry.size {
+            let new_offset = data.open_files[file_idx].current_offset + to_copy;
+            if new_offset > data.open_files[file_idx].entry.size {
                 // We made it longer
-                self.open_files[file_idx].update_length(new_offset);
+                data.open_files[file_idx].update_length(new_offset);
             }
-            self.open_files[file_idx]
+            data.open_files[file_idx]
                 .seek_from_start(new_offset)
                 .unwrap();
             // Entry update deferred to file close, for performance.
         }
-        self.open_files[file_idx].entry.attributes.set_archive(true);
-        self.open_files[file_idx].entry.mtime = self.time_source.get_timestamp();
+        data.open_files[file_idx].entry.attributes.set_archive(true);
+        data.open_files[file_idx].entry.mtime = self.time_source.get_timestamp();
         Ok(())
     }
 
     /// Close a file with the given raw file handle.
-    pub fn close_file(&mut self, file: RawFile) -> Result<(), Error<D::Error>> {
+    pub fn close_file(&self, file: RawFile) -> Result<(), Error<D::Error>> {
         let flush_result = self.flush_file(file);
-        let file_idx = self.get_file_by_id(file)?;
-        self.open_files.swap_remove(file_idx);
+        let mut data = self.data.borrow_mut();
+        let file_idx = data.get_file_by_id(file)?;
+        data.open_files.swap_remove(file_idx);
         flush_result
     }
 
     /// Flush (update the entry) for a file with the given raw file handle.
-    pub fn flush_file(&mut self, file: RawFile) -> Result<(), Error<D::Error>> {
-        let file_info = self
-            .open_files
-            .iter()
-            .find(|info| info.raw_file == file)
-            .ok_or(Error::BadHandle)?;
+    pub fn flush_file(&self, file: RawFile) -> Result<(), Error<D::Error>> {
+        use core::ops::DerefMut;
+        let mut data = self.data.borrow_mut();
+        let data = data.deref_mut();
 
-        if file_info.dirty {
-            let volume_idx = self.get_volume_by_id(file_info.raw_volume)?;
-            match self.open_volumes[volume_idx].volume_type {
-                VolumeType::Fat(ref mut fat) => {
+        let file_id = data.get_file_by_id(file)?;
+
+        if data.open_files[file_id].dirty {
+            let volume_idx = data.get_volume_by_id(data.open_files[file_id].raw_volume)?;
+            match &mut data.open_volumes[volume_idx].volume_type {
+                VolumeType::Fat(fat) => {
                     debug!("Updating FAT info sector");
                     fat.update_info_sector(&self.block_device)?;
-                    debug!("Updating dir entry {:?}", file_info.entry);
-                    if file_info.entry.size != 0 {
+                    debug!("Updating dir entry {:?}", data.open_files[file_id].entry);
+                    if data.open_files[file_id].entry.size != 0 {
                         // If you have a length, you must have a cluster
-                        assert!(file_info.entry.cluster.0 != 0);
+                        assert!(data.open_files[file_id].entry.cluster.0 != 0);
                     }
-                    fat.write_entry_to_disk(&self.block_device, &file_info.entry)?;
+                    fat.write_entry_to_disk(&self.block_device, &data.open_files[file_id].entry)?;
                 }
             };
         }
@@ -844,7 +836,8 @@ where
 
     /// Check if any files or folders are open.
     pub fn has_open_handles(&self) -> bool {
-        !(self.open_dirs.is_empty() || self.open_files.is_empty())
+        let data = self.data.borrow();
+        !(data.open_dirs.is_empty() || data.open_files.is_empty())
     }
 
     /// Consume self and return BlockDevice and TimeSource
@@ -854,18 +847,16 @@ where
 
     /// Check if a file is at End Of File.
     pub fn file_eof(&self, file: RawFile) -> Result<bool, Error<D::Error>> {
-        let file_idx = self.get_file_by_id(file)?;
-        Ok(self.open_files[file_idx].eof())
+        let data = self.data.borrow();
+        let file_idx = data.get_file_by_id(file)?;
+        Ok(data.open_files[file_idx].eof())
     }
 
     /// Seek a file with an offset from the start of the file.
-    pub fn file_seek_from_start(
-        &mut self,
-        file: RawFile,
-        offset: u32,
-    ) -> Result<(), Error<D::Error>> {
-        let file_idx = self.get_file_by_id(file)?;
-        self.open_files[file_idx]
+    pub fn file_seek_from_start(&self, file: RawFile, offset: u32) -> Result<(), Error<D::Error>> {
+        let mut data = self.data.borrow_mut();
+        let file_idx = data.get_file_by_id(file)?;
+        data.open_files[file_idx]
             .seek_from_start(offset)
             .map_err(|_| Error::InvalidOffset)?;
         Ok(())
@@ -873,25 +864,23 @@ where
 
     /// Seek a file with an offset from the current position.
     pub fn file_seek_from_current(
-        &mut self,
+        &self,
         file: RawFile,
         offset: i32,
     ) -> Result<(), Error<D::Error>> {
-        let file_idx = self.get_file_by_id(file)?;
-        self.open_files[file_idx]
+        let mut data = self.data.borrow_mut();
+        let file_idx = data.get_file_by_id(file)?;
+        data.open_files[file_idx]
             .seek_from_current(offset)
             .map_err(|_| Error::InvalidOffset)?;
         Ok(())
     }
 
     /// Seek a file with an offset back from the end of the file.
-    pub fn file_seek_from_end(
-        &mut self,
-        file: RawFile,
-        offset: u32,
-    ) -> Result<(), Error<D::Error>> {
-        let file_idx = self.get_file_by_id(file)?;
-        self.open_files[file_idx]
+    pub fn file_seek_from_end(&self, file: RawFile, offset: u32) -> Result<(), Error<D::Error>> {
+        let mut data = self.data.borrow_mut();
+        let file_idx = data.get_file_by_id(file)?;
+        data.open_files[file_idx]
             .seek_from_end(offset)
             .map_err(|_| Error::InvalidOffset)?;
         Ok(())
@@ -899,35 +888,41 @@ where
 
     /// Get the length of a file
     pub fn file_length(&self, file: RawFile) -> Result<u32, Error<D::Error>> {
-        let file_idx = self.get_file_by_id(file)?;
-        Ok(self.open_files[file_idx].length())
+        let data = self.data.borrow();
+        let file_idx = data.get_file_by_id(file)?;
+        Ok(data.open_files[file_idx].length())
     }
 
     /// Get the current offset of a file
     pub fn file_offset(&self, file: RawFile) -> Result<u32, Error<D::Error>> {
-        let file_idx = self.get_file_by_id(file)?;
-        Ok(self.open_files[file_idx].current_offset)
+        let data = self.data.borrow();
+        let file_idx = data.get_file_by_id(file)?;
+        Ok(data.open_files[file_idx].current_offset)
     }
 
     /// Create a directory in a given directory.
     pub fn make_dir_in_dir<N>(
-        &mut self,
+        &self,
         directory: RawDirectory,
         name: N,
     ) -> Result<(), Error<D::Error>>
     where
         N: ToShortFileName,
     {
+        use core::ops::DerefMut;
+        let mut data = self.data.borrow_mut();
+        let data = data.deref_mut();
+
         // This check is load-bearing - we do an unchecked push later.
-        if self.open_dirs.is_full() {
+        if data.open_dirs.is_full() {
             return Err(Error::TooManyOpenDirs);
         }
 
-        let parent_directory_idx = self.get_dir_by_id(directory)?;
-        let parent_directory_info = &self.open_dirs[parent_directory_idx];
-        let volume_id = self.open_dirs[parent_directory_idx].volume_id;
-        let volume_idx = self.get_volume_by_id(volume_id)?;
-        let volume_info = &self.open_volumes[volume_idx];
+        let parent_directory_idx = data.get_dir_by_id(directory)?;
+        let parent_directory_info = &data.open_dirs[parent_directory_idx];
+        let volume_id = data.open_dirs[parent_directory_idx].raw_volume;
+        let volume_idx = data.get_volume_by_id(volume_id)?;
+        let volume_info = &data.open_volumes[volume_idx];
         let sfn = name.to_short_filename().map_err(Error::FilenameError)?;
 
         debug!("Creating directory '{}'", sfn);
@@ -962,7 +957,7 @@ where
         let att = Attributes::create_from_fat(Attributes::DIRECTORY);
 
         // Need mutable access for this
-        match &mut self.open_volumes[volume_idx].volume_type {
+        match &mut data.open_volumes[volume_idx].volume_type {
             VolumeType::Fat(fat) => {
                 debug!("Making dir entry");
                 let mut new_dir_entry_in_parent = fat.write_new_directory_entry(
@@ -1048,28 +1043,72 @@ where
 
         Ok(())
     }
+}
 
-    fn get_volume_by_id(&self, volume: RawVolume) -> Result<usize, Error<D::Error>> {
+/// The mutable data the VolumeManager needs to hold
+///
+/// Kept separate so its easier to wrap it in a RefCell
+#[derive(Debug)]
+
+struct VolumeManagerData<
+    const MAX_DIRS: usize = 4,
+    const MAX_FILES: usize = 4,
+    const MAX_VOLUMES: usize = 1,
+> {
+    id_generator: HandleGenerator,
+    open_volumes: Vec<VolumeInfo, MAX_VOLUMES>,
+    open_dirs: Vec<DirectoryInfo, MAX_DIRS>,
+    open_files: Vec<FileInfo, MAX_FILES>,
+}
+
+impl<const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>
+    VolumeManagerData<MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+{
+    /// Check if a file is open
+    ///
+    /// Returns `true` if it's open, `false`, otherwise.
+    fn file_is_open(&self, raw_volume: RawVolume, dir_entry: &DirEntry) -> bool {
+        for f in self.open_files.iter() {
+            if f.raw_volume == raw_volume
+                && f.entry.entry_block == dir_entry.entry_block
+                && f.entry.entry_offset == dir_entry.entry_offset
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn get_volume_by_id<E>(&self, raw_volume: RawVolume) -> Result<usize, Error<E>>
+    where
+        E: core::fmt::Debug,
+    {
         for (idx, v) in self.open_volumes.iter().enumerate() {
-            if v.raw_volume == volume {
+            if v.raw_volume == raw_volume {
                 return Ok(idx);
             }
         }
         Err(Error::BadHandle)
     }
 
-    fn get_dir_by_id(&self, directory: RawDirectory) -> Result<usize, Error<D::Error>> {
+    fn get_dir_by_id<E>(&self, raw_directory: RawDirectory) -> Result<usize, Error<E>>
+    where
+        E: core::fmt::Debug,
+    {
         for (idx, d) in self.open_dirs.iter().enumerate() {
-            if d.directory_id == directory {
+            if d.raw_directory == raw_directory {
                 return Ok(idx);
             }
         }
         Err(Error::BadHandle)
     }
 
-    fn get_file_by_id(&self, file: RawFile) -> Result<usize, Error<D::Error>> {
+    fn get_file_by_id<E>(&self, raw_file: RawFile) -> Result<usize, Error<E>>
+    where
+        E: core::fmt::Debug,
+    {
         for (idx, f) in self.open_files.iter().enumerate() {
-            if f.raw_file == file {
+            if f.raw_file == raw_file {
                 return Ok(idx);
             }
         }
@@ -1085,13 +1124,17 @@ where
     /// * the index for the block on the disk that contains the data we want,
     /// * the byte offset into that block for the data we want, and
     /// * how many bytes remain in that block.
-    fn find_data_on_disk(
+    fn find_data_on_disk<D>(
         &self,
+        block_device: &D,
         volume_idx: usize,
         start: &mut (u32, ClusterId),
         file_start: ClusterId,
         desired_offset: u32,
-    ) -> Result<(BlockIdx, usize, usize), Error<D::Error>> {
+    ) -> Result<(BlockIdx, usize, usize), Error<D::Error>>
+    where
+        D: BlockDevice,
+    {
         let bytes_per_cluster = match &self.open_volumes[volume_idx].volume_type {
             VolumeType::Fat(fat) => fat.bytes_per_cluster(),
         };
@@ -1110,7 +1153,7 @@ where
         for _ in 0..num_clusters {
             start.1 = match &self.open_volumes[volume_idx].volume_type {
                 VolumeType::Fat(fat) => {
-                    fat.next_cluster(&self.block_device, start.1, &mut block_cache)?
+                    fat.next_cluster(block_device, start.1, &mut block_cache)?
                 }
             };
             start.0 += bytes_per_cluster;
@@ -1392,14 +1435,14 @@ mod tests {
 
     #[test]
     fn partition0() {
-        let mut c: VolumeManager<DummyBlockDevice, Clock, 2, 2> =
+        let c: VolumeManager<DummyBlockDevice, Clock, 2, 2> =
             VolumeManager::new_with_limits(DummyBlockDevice, Clock, 0xAA00_0000);
 
         let v = c.open_raw_volume(VolumeIdx(0)).unwrap();
         let expected_id = RawVolume(Handle(0xAA00_0000));
         assert_eq!(v, expected_id);
         assert_eq!(
-            &c.open_volumes[0],
+            &c.data.borrow().open_volumes[0],
             &VolumeInfo {
                 raw_volume: expected_id,
                 idx: VolumeIdx(0),

--- a/tests/directories.rs
+++ b/tests/directories.rs
@@ -38,7 +38,7 @@ impl PartialEq<embedded_sdmmc::DirEntry> for ExpectedDirEntry {
 fn fat16_root_directory_listing() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat16_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
@@ -100,7 +100,7 @@ fn fat16_root_directory_listing() {
 fn fat16_sub_directory_listing() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat16_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
@@ -165,7 +165,7 @@ fn fat16_sub_directory_listing() {
 fn fat32_root_directory_listing() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat32_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(1))
@@ -227,7 +227,7 @@ fn fat32_root_directory_listing() {
 fn open_dir_twice() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat32_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(1))
@@ -267,7 +267,7 @@ fn open_dir_twice() {
 fn open_too_many_dirs() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr: embedded_sdmmc::VolumeManager<
+    let volume_mgr: embedded_sdmmc::VolumeManager<
         utils::RamDisk<Vec<u8>>,
         utils::TestTimeSource,
         1,
@@ -292,7 +292,7 @@ fn open_too_many_dirs() {
 fn find_dir_entry() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat32_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(1))
@@ -322,7 +322,7 @@ fn find_dir_entry() {
 fn delete_file() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat32_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(1))
@@ -367,7 +367,7 @@ fn delete_file() {
 fn make_directory() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat32_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(1))

--- a/tests/open_files.rs
+++ b/tests/open_files.rs
@@ -8,7 +8,7 @@ mod utils;
 fn open_files() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
+    let volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
         VolumeManager::new_with_limits(disk, time_source, 0xAA00_0000);
     let volume = volume_mgr
         .open_raw_volume(VolumeIdx(0))
@@ -95,11 +95,11 @@ fn open_files() {
 fn open_non_raw() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
+    let volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
         VolumeManager::new_with_limits(disk, time_source, 0xAA00_0000);
-    let mut volume = volume_mgr.open_volume(VolumeIdx(0)).expect("open volume");
-    let mut root_dir = volume.open_root_dir().expect("open root dir");
-    let mut f = root_dir
+    let volume = volume_mgr.open_volume(VolumeIdx(0)).expect("open volume");
+    let root_dir = volume.open_root_dir().expect("open root dir");
+    let f = root_dir
         .open_file_in_dir("README.TXT", Mode::ReadOnly)
         .expect("open file");
 

--- a/tests/read_file.rs
+++ b/tests/read_file.rs
@@ -11,7 +11,7 @@ static TEST_DAT_SHA256_SUM: &[u8] =
 fn read_file_512_blocks() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat16_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
@@ -53,7 +53,7 @@ fn read_file_512_blocks() {
 fn read_file_all() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat16_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
@@ -87,7 +87,7 @@ fn read_file_all() {
 fn read_file_prime_blocks() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat16_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
@@ -130,7 +130,7 @@ fn read_file_prime_blocks() {
 fn read_file_backwards() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let fat16_volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
@@ -188,13 +188,13 @@ fn read_file_backwards() {
 fn read_file_with_odd_seek() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
-    let mut volume = volume_mgr
+    let volume = volume_mgr
         .open_volume(embedded_sdmmc::VolumeIdx(0))
         .unwrap();
-    let mut root_dir = volume.open_root_dir().unwrap();
-    let mut f = root_dir
+    let root_dir = volume.open_root_dir().unwrap();
+    let f = root_dir
         .open_file_in_dir("64MB.DAT", embedded_sdmmc::Mode::ReadOnly)
         .unwrap();
     f.seek_from_start(0x2c).unwrap();

--- a/tests/volume.rs
+++ b/tests/volume.rs
@@ -6,7 +6,7 @@ mod utils;
 fn open_all_volumes() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr: embedded_sdmmc::VolumeManager<
+    let volume_mgr: embedded_sdmmc::VolumeManager<
         utils::RamDisk<Vec<u8>>,
         utils::TestTimeSource,
         4,
@@ -82,7 +82,7 @@ fn open_all_volumes() {
 fn close_volume_too_early() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
 
     let volume = volume_mgr
         .open_raw_volume(embedded_sdmmc::VolumeIdx(0))

--- a/tests/write_file.rs
+++ b/tests/write_file.rs
@@ -8,7 +8,7 @@ mod utils;
 fn append_file() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
+    let volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
         VolumeManager::new_with_limits(disk, time_source, 0xAA00_0000);
     let volume = volume_mgr
         .open_raw_volume(VolumeIdx(0))
@@ -59,7 +59,7 @@ fn append_file() {
 fn flush_file() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
-    let mut volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
+    let volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
         VolumeManager::new_with_limits(disk, time_source, 0xAA00_0000);
     let volume = volume_mgr
         .open_raw_volume(VolumeIdx(0))


### PR DESCRIPTION
VolumeManager now contains a RefCell, so all the methods can be `&self`. This also means you can have multiple smart handles usable at the same time.

Note that VolumeManager is !Sync, so this is just about having multiple `File` objects active at one time.

Closes #79 (finally!)
