### PR TITLE
Better volume label support

### DIFF
--- a/src/fat/bpb.rs
+++ b/src/fat/bpb.rs
@@ -85,11 +85,13 @@ impl<'a> Bpb<'a> {
     // FAT16/FAT32 functions
 
     /// Get the Volume Label string for this volume
-    pub fn volume_label(&self) -> &[u8] {
+    pub fn volume_label(&self) -> [u8; 11] {
+        let mut result = [0u8; 11];
         match self.fat_type {
-            FatType::Fat16 => &self.data[43..=53],
-            FatType::Fat32 => &self.data[71..=81],
+            FatType::Fat16 => result.copy_from_slice(&self.data[43..=53]),
+            FatType::Fat32 => result.copy_from_slice(&self.data[71..=81]),
         }
+        result
     }
 
     // FAT32 only functions

--- a/src/fat/bpb.rs
+++ b/src/fat/bpb.rs
@@ -86,10 +86,9 @@ impl<'a> Bpb<'a> {
 
     /// Get the Volume Label string for this volume
     pub fn volume_label(&self) -> &[u8] {
-        if self.fat_type != FatType::Fat32 {
-            &self.data[43..=53]
-        } else {
-            &self.data[71..=81]
+        match self.fat_type {
+            FatType::Fat16 => &self.data[43..=53],
+            FatType::Fat32 => &self.data[71..=81],
         }
     }
 
@@ -98,10 +97,9 @@ impl<'a> Bpb<'a> {
     /// On a FAT32 volume, return the free block count from the Info Block. On
     /// a FAT16 volume, returns None.
     pub fn fs_info_block(&self) -> Option<BlockCount> {
-        if self.fat_type != FatType::Fat32 {
-            None
-        } else {
-            Some(BlockCount(u32::from(self.fs_info())))
+        match self.fat_type {
+            FatType::Fat16 => None,
+            FatType::Fat32 => Some(BlockCount(u32::from(self.fs_info()))),
         }
     }
 

--- a/src/fat/mod.rs
+++ b/src/fat/mod.rs
@@ -139,7 +139,11 @@ mod test {
         "#;
         let results = [
             Expected::Short(DirEntry {
-                name: ShortFileName::create_from_str_mixed_case("boot").unwrap(),
+                name: unsafe {
+                    VolumeName::create_from_str("boot")
+                        .unwrap()
+                        .to_short_filename()
+                },
                 mtime: Timestamp::from_calendar(2015, 11, 21, 19, 35, 18).unwrap(),
                 ctime: Timestamp::from_calendar(2015, 11, 21, 19, 35, 18).unwrap(),
                 attributes: Attributes::create_from_fat(Attributes::VOLUME),
@@ -349,7 +353,7 @@ mod test {
         assert_eq!(bpb.fat_size16(), 32);
         assert_eq!(bpb.total_blocks32(), 122_880);
         assert_eq!(bpb.footer(), 0xAA55);
-        assert_eq!(bpb.volume_label(), b"boot       ");
+        assert_eq!(bpb.volume_label(), *b"boot       ");
         assert_eq!(bpb.fat_size(), 32);
         assert_eq!(bpb.total_blocks(), 122_880);
         assert_eq!(bpb.fat_type, FatType::Fat16);

--- a/src/fat/volume.rs
+++ b/src/fat/volume.rs
@@ -587,8 +587,8 @@ impl FatVolume {
                         // Can quit early
                         return Ok(());
                     } else if dir_entry.is_valid() && !dir_entry.is_lfn() {
-                        // Safe, since Block::LEN always fits on a u32
-                        let start = u32::try_from(start).unwrap();
+                        // Block::LEN always fits on a u32
+                        let start = start as u32;
                         let entry = dir_entry.get_entry(FatType::Fat16, block_idx, start);
                         func(&entry);
                     }
@@ -642,8 +642,8 @@ impl FatVolume {
                         // Can quit early
                         return Ok(());
                     } else if dir_entry.is_valid() && !dir_entry.is_lfn() {
-                        // Safe, since Block::LEN always fits on a u32
-                        let start = u32::try_from(start).unwrap();
+                        // Block::LEN always fits on a u32
+                        let start = start as u32;
                         let entry = dir_entry.get_entry(FatType::Fat32, block, start);
                         func(&entry);
                     }
@@ -769,8 +769,8 @@ impl FatVolume {
                 break;
             } else if dir_entry.matches(match_name) {
                 // Found it
-                // Safe, since Block::LEN always fits on a u32
-                let start = u32::try_from(start).unwrap();
+                // Block::LEN always fits on a u32
+                let start = start as u32;
                 return Ok(dir_entry.get_entry(fat_type, block, start));
             }
         }

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -1,5 +1,3 @@
-use core::convert::TryFrom;
-
 use crate::blockdevice::BlockIdx;
 use crate::fat::{FatType, OnDiskDirEntry};
 use crate::filesystem::{Attributes, ClusterId, Handle, ShortFileName, Timestamp};
@@ -262,16 +260,12 @@ impl DirEntry {
             [0u8; 2]
         } else {
             // Safe due to the AND operation
-            u16::try_from((cluster_number >> 16) & 0x0000_FFFF)
-                .unwrap()
-                .to_le_bytes()
+            (((cluster_number >> 16) & 0x0000_FFFF) as u16).to_le_bytes()
         };
         data[20..22].copy_from_slice(&cluster_hi[..]);
         data[22..26].copy_from_slice(&self.mtime.serialize_to_fat()[..]);
         // Safe due to the AND operation
-        let cluster_lo = u16::try_from(cluster_number & 0x0000_FFFF)
-            .unwrap()
-            .to_le_bytes();
+        let cluster_lo = ((cluster_number & 0x0000_FFFF) as u16).to_le_bytes();
         data[26..28].copy_from_slice(&cluster_lo[..]);
         data[28..32].copy_from_slice(&self.size.to_le_bytes()[..]);
         data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ use filesystem::Handle;
 pub use crate::blockdevice::{Block, BlockCount, BlockDevice, BlockIdx};
 
 #[doc(inline)]
-pub use crate::fat::FatVolume;
+pub use crate::fat::{FatVolume, VolumeName};
 
 #[doc(inline)]
 pub use crate::filesystem::{

--- a/tests/volume.rs
+++ b/tests/volume.rs
@@ -60,6 +60,12 @@ fn open_all_volumes() {
 
     // This isn't a valid volume
     assert!(matches!(
+        volume_mgr.open_raw_volume(embedded_sdmmc::VolumeIdx(3)),
+        Err(embedded_sdmmc::Error::FormatError(_e))
+    ));
+
+    // This isn't a valid volume
+    assert!(matches!(
         volume_mgr.open_raw_volume(embedded_sdmmc::VolumeIdx(9)),
         Err(embedded_sdmmc::Error::NoSuchVolume)
     ));


### PR DESCRIPTION
Now you can ask for the label of a volume. The `shell` example also now prints the volume label on start-up.

```console
$ cargo run --example shell --release -- ./disk.img
    Finished `release` profile [optimized] target(s) in 0.03s
     Running `target/release/examples/shell ./disk.img`
Opening './disk.img'...
Volume # A: found, label: Some(VolumeName("TEST FAT16"))
Volume # B: found, label: Some(VolumeName("TEST FAT32"))
Failed to open volume 2: FormatError("Partition type not supported")
Failed to open volume 3: FormatError("Partition type not supported")
A:/> 
```