### PR TITLE
Use chunks_exact and remove 'reason' from BlockDevice API

### DIFF
--- a/examples/linux/mod.rs
+++ b/examples/linux/mod.rs
@@ -34,22 +34,14 @@ impl LinuxBlockDevice {
 impl BlockDevice for LinuxBlockDevice {
     type Error = std::io::Error;
 
-    fn read(
-        &self,
-        blocks: &mut [Block],
-        start_block_idx: BlockIdx,
-        reason: &str,
-    ) -> Result<(), Self::Error> {
+    fn read(&self, blocks: &mut [Block], start_block_idx: BlockIdx) -> Result<(), Self::Error> {
         self.file
             .borrow_mut()
             .seek(SeekFrom::Start(start_block_idx.into_bytes()))?;
         for block in blocks.iter_mut() {
             self.file.borrow_mut().read_exact(&mut block.contents)?;
             if self.print_blocks {
-                println!(
-                    "Read block ({}) {:?}: {:?}",
-                    reason, start_block_idx, &block
-                );
+                println!("Read block {:?}: {:?}", start_block_idx, &block);
             }
         }
         Ok(())

--- a/src/blockdevice.rs
+++ b/src/blockdevice.rs
@@ -43,12 +43,7 @@ pub trait BlockDevice {
     /// The errors that the `BlockDevice` can return. Must be debug formattable.
     type Error: core::fmt::Debug;
     /// Read one or more blocks, starting at the given block index.
-    fn read(
-        &self,
-        blocks: &mut [Block],
-        start_block_idx: BlockIdx,
-        reason: &str,
-    ) -> Result<(), Self::Error>;
+    fn read(&self, blocks: &mut [Block], start_block_idx: BlockIdx) -> Result<(), Self::Error>;
     /// Write one or more blocks, starting at the given block index.
     fn write(&self, blocks: &[Block], start_block_idx: BlockIdx) -> Result<(), Self::Error>;
     /// Determine how many blocks this device can hold.

--- a/src/fat/mod.rs
+++ b/src/fat/mod.rs
@@ -29,7 +29,6 @@ impl BlockCache {
         &mut self,
         block_device: &D,
         block_idx: BlockIdx,
-        reason: &str,
     ) -> Result<&Block, Error<D::Error>>
     where
         D: BlockDevice,
@@ -37,7 +36,7 @@ impl BlockCache {
         if Some(block_idx) != self.idx {
             self.idx = Some(block_idx);
             block_device
-                .read(core::slice::from_mut(&mut self.block), block_idx, reason)
+                .read(core::slice::from_mut(&mut self.block), block_idx)
                 .map_err(Error::DeviceError)?;
         }
         Ok(&self.block)

--- a/src/sdcard/mod.rs
+++ b/src/sdcard/mod.rs
@@ -162,19 +162,9 @@ where
     /// Read one or more blocks, starting at the given block index.
     ///
     /// This will trigger card (re-)initialisation.
-    fn read(
-        &self,
-        blocks: &mut [Block],
-        start_block_idx: BlockIdx,
-        _reason: &str,
-    ) -> Result<(), Self::Error> {
+    fn read(&self, blocks: &mut [Block], start_block_idx: BlockIdx) -> Result<(), Self::Error> {
         let mut inner = self.inner.borrow_mut();
-        debug!(
-            "Read {} blocks @ {} for {}",
-            blocks.len(),
-            start_block_idx.0,
-            _reason
-        );
+        debug!("Read {} blocks @ {}", blocks.len(), start_block_idx.0,);
         inner.check_init()?;
         inner.read(blocks, start_block_idx)
     }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -85,12 +85,7 @@ where
 {
     type Error = Error;
 
-    fn read(
-        &self,
-        blocks: &mut [Block],
-        start_block_idx: BlockIdx,
-        _reason: &str,
-    ) -> Result<(), Self::Error> {
+    fn read(&self, blocks: &mut [Block], start_block_idx: BlockIdx) -> Result<(), Self::Error> {
         let borrow = self.contents.borrow();
         let contents: &[u8] = borrow.as_ref();
         let mut block_idx = start_block_idx;


### PR DESCRIPTION
Some clean ups in the EuroRust 2024 impl room.

) Removed the reason field from the Block Device API. It didn't get used much and the caller can just do the logging. We didn't even log writes and they're more important.
) Addeded trace logging for reads/writes.
) Use chunks_exact to simplfy some loops
