### PR TITLE
Backport some fixes to 0.8 branch

### DIFF
--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -324,6 +324,13 @@ where
         }
 
         let volume_idx = self.get_volume_by_id(volume)?;
+
+        match &mut self.open_volumes[volume_idx].volume_type {
+            VolumeType::Fat(fat_volume) => {
+                fat_volume.update_info_sector(&self.block_device)?;
+            }
+        }
+
         self.open_volumes.swap_remove(volume_idx);
 
         Ok(())

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -1381,6 +1381,7 @@ mod tests {
                     blocks_per_cluster: 8,
                     first_data_block: BlockCount(15136),
                     fat_start: BlockCount(32),
+                    second_fat_start: Some(BlockCount(32 + 0x0000_1D80)),
                     name: fat::VolumeName::new(*b"Pictures   "),
                     free_clusters_count: None,
                     next_free_cluster: None,

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -5,7 +5,7 @@
 use byteorder::{ByteOrder, LittleEndian};
 use core::convert::TryFrom;
 
-use crate::fat::{self, BlockCache, FatType, OnDiskDirEntry, RESERVED_ENTRIES};
+use crate::fat::{self, BlockCache, OnDiskDirEntry, RESERVED_ENTRIES};
 
 use crate::filesystem::{
     Attributes, ClusterId, DirEntry, DirectoryInfo, FileInfo, Mode, RawDirectory, RawFile,
@@ -978,16 +978,13 @@ where
                     ctime: now,
                     attributes: att,
                     // point at our parent
-                    cluster: match fat_type {
-                        FatType::Fat16 => {
-                            // On FAT16, indicate parent is root using Cluster(0)
-                            if parent_directory_info.cluster == ClusterId::ROOT_DIR {
-                                ClusterId::EMPTY
-                            } else {
-                                parent_directory_info.cluster
-                            }
+                    cluster: {
+                        // On FAT16, indicate parent is root using Cluster(0)
+                        if parent_directory_info.cluster == ClusterId::ROOT_DIR {
+                            ClusterId::EMPTY
+                        } else {
+                            parent_directory_info.cluster
                         }
-                        FatType::Fat32 => parent_directory_info.cluster,
                     },
                     size: 0,
                     entry_block: new_dir_start_block,


### PR DESCRIPTION
* Write out info sector when volume closed
* Get `..` dir entry correct
* Write to second FAT

Now fsck should stop complaining about volumes that were written to with this crate.
