### PR TITLE
Add support for partition id 04h

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,9 @@ const PARTITION_ID_FAT16_LBA: u8 = 0x0E;
 /// Marker for a FAT16 partition. Seen on a card formatted with the official
 /// SD-Card formatter.
 const PARTITION_ID_FAT16: u8 = 0x06;
+/// Marker for a FAT16 partition smaller than 32MB. Seen on the wowki simulated
+/// microsd card
+const PARTITION_ID_FAT16_SMALL: u8 = 0x04;
 /// Marker for a FAT32 partition. What Macosx disk utility (and also SD-Card formatter?)
 /// use.
 const PARTITION_ID_FAT32_CHS_LBA: u8 = 0x0B;

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     trace, Block, BlockCache, BlockCount, BlockDevice, BlockIdx, Error, RawVolume, ShortFileName,
     Volume, VolumeIdx, VolumeInfo, VolumeType, PARTITION_ID_FAT16, PARTITION_ID_FAT16_LBA,
-    PARTITION_ID_FAT32_CHS_LBA, PARTITION_ID_FAT32_LBA,
+    PARTITION_ID_FAT16_SMALL, PARTITION_ID_FAT32_CHS_LBA, PARTITION_ID_FAT32_LBA,
 };
 
 /// Wraps a block device and gives access to the FAT-formatted volumes within
@@ -195,7 +195,8 @@ where
             PARTITION_ID_FAT32_CHS_LBA
             | PARTITION_ID_FAT32_LBA
             | PARTITION_ID_FAT16_LBA
-            | PARTITION_ID_FAT16 => {
+            | PARTITION_ID_FAT16
+            | PARTITION_ID_FAT16_SMALL => {
                 let volume = fat::parse_volume(&mut data.block_cache, lba_start, num_blocks)?;
                 let id = RawVolume(data.id_generator.generate());
                 let info = VolumeInfo {


### PR DESCRIPTION
[Wikipedia claims](https://en.wikipedia.org/wiki/Partition_type) that `04h` is for FAT16 with less than 65,536 sectors. This PR adds it to the list of accepted partition IDs. It was seen on the [Wowki simulated microsd card](https://docs.wokwi.com/parts/wokwi-microsd-card/)