### PR TITLE
test: create file then append data

### DIFF
--- a/tests/write_file.rs
+++ b/tests/write_file.rs
@@ -67,15 +67,20 @@ fn create_file_then_append() {
     // Check that the file doesn't exist yet
     let files = {
         let mut files = Vec::new();
-        root_dir.iterate_dir(|entry| {
-            files.push(entry.name.clone());
-        })
-        .expect("iterate dir");
+        root_dir
+            .iterate_dir(|entry| {
+                files.push(entry.name.clone());
+            })
+            .expect("iterate dir");
         files
     };
-    assert_eq!(None, files.iter().find(|&x| core::str::from_utf8(x.base_name()).unwrap() == "README_2"));
-    
-    
+    assert_eq!(
+        None,
+        files
+            .iter()
+            .find(|&x| core::str::from_utf8(x.base_name()).unwrap() == "README_2")
+    );
+
     // Create it:
     {
         let file = root_dir
@@ -95,13 +100,19 @@ fn create_file_then_append() {
     // Check that it now exists
     let files = {
         let mut files = Vec::new();
-        root_dir.iterate_dir(|entry| {
-            files.push(entry.name.clone());
-        })
-        .expect("iterate dir");
+        root_dir
+            .iterate_dir(|entry| {
+                files.push(entry.name.clone());
+            })
+            .expect("iterate dir");
         files
     };
-    assert_ne!(None, files.iter().find(|&x| core::str::from_utf8(x.base_name()).unwrap() == "README_2"));
+    assert_ne!(
+        None,
+        files
+            .iter()
+            .find(|&x| core::str::from_utf8(x.base_name()).unwrap() == "README_2")
+    );
 
     // Append to it:
     for i in 0..10 {


### PR DESCRIPTION
Initiated from #172 - it was recommended to add a test case to further investigate my issue.

The added test confirms that opening a file as `ReadWriteCreateOrAppend` and then writing to it several times works properly.

