### PR TITLE
docs: README write to file example; reminder to run `file.flush()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ while !my_file.is_eof() {
 }
 ```
 
+For writing files:
+```rust
+let my_other_file = root_dir.open_file_in_dir("MY_OTHER_FILE.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
+my_other_file.write(b"Timestamp,Signal,Value\n")?;
+my_other_file.write(b"2025-01-01T00:00:00Z,TEMP,25.0\n")?;
+my_other_file.write(b"2025-01-01T00:00:01Z,TEMP,25.1\n")?;
+my_other_file.write(b"2025-01-01T00:00:02Z,TEMP,25.2\n")?;
+
+// Don't forget to flush the file so that the directory entry is updated
+my_other_file.flush()?;
+```
+
 ### Open directories and files
 
 By default the `VolumeManager` will initialize with a maximum number of `4` open directories, files and volumes. This can be customized by specifying the `MAX_DIR`, `MAX_FILES` and `MAX_VOLUMES` generic consts of the `VolumeManager`:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ while !my_file.is_eof() {
 
 For writing files:
 ```rust
-let my_other_file = root_dir.open_file_in_dir("MY_OTHER_FILE.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
+let my_other_file = root_dir.open_file_in_dir("FILE2.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
 my_other_file.write(b"Timestamp,Signal,Value\n")?;
 my_other_file.write(b"2025-01-01T00:00:00Z,TEMP,25.0\n")?;
 my_other_file.write(b"2025-01-01T00:00:01Z,TEMP,25.1\n")?;

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ while !my_file.is_eof() {
 
 For writing files:
 ```rust
-let my_other_file = root_dir.open_file_in_dir("FILE2.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
+let my_other_file = root_dir.open_file_in_dir("MY_DATA.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
 my_other_file.write(b"Timestamp,Signal,Value\n")?;
 my_other_file.write(b"2025-01-01T00:00:00Z,TEMP,25.0\n")?;
 my_other_file.write(b"2025-01-01T00:00:01Z,TEMP,25.1\n")?;

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ while !my_file.is_eof() {
 ```
 
 For writing files:
+
 ```rust
 let my_other_file = root_dir.open_file_in_dir("MY_DATA.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
 my_other_file.write(b"Timestamp,Signal,Value\n")?;


### PR DESCRIPTION
Adding example of writing to files in the code snippet. Includes a reminder to run `file.flush()` so that directory entry is updated (I has missed this resulting in #172).

```rust
let my_other_file = root_dir.open_file_in_dir("MY_DATA.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
my_other_file.write(b"Timestamp,Signal,Value\n")?;
my_other_file.write(b"2025-01-01T00:00:00Z,TEMP,25.0\n")?;
my_other_file.write(b"2025-01-01T00:00:01Z,TEMP,25.1\n")?;
my_other_file.write(b"2025-01-01T00:00:02Z,TEMP,25.2\n")?;

// Don't forget to flush the file so that the directory entry is updated
my_other_file.flush()?;
```