### PR TITLE
docs: adds same snippet of writing to files to `lib.rs` for crate doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,15 +45,21 @@
 //!
 //! For writing files:
 //!
-//! ```rust,ignore
-//! let my_other_file = root_dir.open_file_in_dir("MY_DATA.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
-//! my_other_file.write(b"Timestamp,Signal,Value\n")?;
-//! my_other_file.write(b"2025-01-01T00:00:00Z,TEMP,25.0\n")?;
-//! my_other_file.write(b"2025-01-01T00:00:01Z,TEMP,25.1\n")?;
-//! my_other_file.write(b"2025-01-01T00:00:02Z,TEMP,25.2\n")?;
-//!
-//! // Don't forget to flush the file so that the directory entry is updated
-//! my_other_file.flush()?;
+//! ```rust
+//! use embedded_sdmmc::{BlockDevice, Directory, Error, Mode, TimeSource};
+//! fn write_file<D: BlockDevice, T: TimeSource, const DIRS: usize, const FILES: usize, const VOLUMES: usize>(
+//!     root_dir: &mut Directory<D, T, DIRS, FILES, VOLUMES>,
+//! ) -> Result<(), Error<D::Error>>
+//! {
+//!     let my_other_file = root_dir.open_file_in_dir("MY_DATA.CSV", Mode::ReadWriteCreateOrAppend)?;
+//!     my_other_file.write(b"Timestamp,Signal,Value\n")?;
+//!     my_other_file.write(b"2025-01-01T00:00:00Z,TEMP,25.0\n")?;
+//!     my_other_file.write(b"2025-01-01T00:00:01Z,TEMP,25.1\n")?;
+//!     my_other_file.write(b"2025-01-01T00:00:02Z,TEMP,25.2\n")?;
+//!     // Don't forget to flush the file so that the directory entry is updated
+//!     my_other_file.flush()?;
+//!     Ok(())
+//! }
 //! ```
 //!
 //! ## Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,19 @@
 //! }
 //! ```
 //!
+//! For writing files:
+//!
+//! ```rust
+//! let my_other_file = root_dir.open_file_in_dir("MY_DATA.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
+//! my_other_file.write(b"Timestamp,Signal,Value\n")?;
+//! my_other_file.write(b"2025-01-01T00:00:00Z,TEMP,25.0\n")?;
+//! my_other_file.write(b"2025-01-01T00:00:01Z,TEMP,25.1\n")?;
+//! my_other_file.write(b"2025-01-01T00:00:02Z,TEMP,25.2\n")?;
+//!
+//! // Don't forget to flush the file so that the directory entry is updated
+//! my_other_file.flush()?;
+//! ```
+//!
 //! ## Features
 //!
 //! * `log`: Enabled by default. Generates log messages using the `log` crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! For writing files:
 //!
-//! ```rust
+//! ```rust,,ignore
 //! let my_other_file = root_dir.open_file_in_dir("MY_DATA.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
 //! my_other_file.write(b"Timestamp,Signal,Value\n")?;
 //! my_other_file.write(b"2025-01-01T00:00:00Z,TEMP,25.0\n")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! For writing files:
 //!
-//! ```rust,,ignore
+//! ```rust,ignore
 //! let my_other_file = root_dir.open_file_in_dir("MY_DATA.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrAppend)?;
 //! my_other_file.write(b"Timestamp,Signal,Value\n")?;
 //! my_other_file.write(b"2025-01-01T00:00:00Z,TEMP,25.0\n")?;


### PR DESCRIPTION
Extension of #174 - adds same doc of snippet for writing to files to `lib.rs` so that it matches there. Tested running with `cargo doc` and it looks as expected.

<img width="1093" alt="image" src="https://github.com/user-attachments/assets/6f6d7d15-26c7-4523-87e3-2150463ad99f" />