### PR TITLE
Remove the create-dir feature from the todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ This repository houses no examples for no-std usage, however you can check out t
 
 ## Todo List (PRs welcome!)
 
-* Create new dirs
 * Delete (empty) directories
 * Handle MS-DOS `/path/foo/bar.txt` style paths.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ let cont: VolumeManager<_, _, 6, 12, 4> = VolumeManager::new_with_limits(block, 
 * Delete files
 * Iterate root directory
 * Iterate sub-directories
+* Create directories
 * Log over defmt or the common log interface (feature flags).
 
 ## No-std usage


### PR DESCRIPTION
As far as I can see, this feature seems to be there. It's in the docs and there are tests for it. Was the removal from the list forgotten or is it not stable enough?

Kind regards and many thanks for this library,
Kasper