### PR TITLE
Fix stack overflow when receiver is typed as embedded_io trait

### DIFF
--- a/src/filesystem/files.rs
+++ b/src/filesystem/files.rs
@@ -190,7 +190,7 @@ impl<
         if buf.is_empty() {
             Ok(0)
         } else {
-            self.read(buf)
+            File::read(self, buf)
         }
     }
 }
@@ -207,7 +207,7 @@ impl<
         if buf.is_empty() {
             Ok(0)
         } else {
-            self.write(buf)?;
+            File::write(self, buf)?;
             Ok(buf.len())
         }
     }


### PR DESCRIPTION
Prevents a stack overflow when the receiver is typed as embedded_io::Read or embedded_io::Write.