### PR TITLE
Update to `defmt` 1.0.1, `embedded-hal-bus` 0.3.0, `env_logger` 0.11.8, `heapless` 0.9.1, and `hex-literal` 1.0.0.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # Always run MSRV too!
-        rust: ["stable", "1.76"]
+        rust: ["stable", "1.86"]
         features: ['log', 'defmt-log', '""']
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 
 ## [Unreleased]
 
+### Changed
+
+- Updated to `defmt` 1.0.1, `embedded-hal-bus` 0.3.0, `env_logger` 0.11.8, `heapless` 0.9.1, and `hex-literal` 1.0.0.
+- Raised the minimum supported Rust version to 1.86.0.
+
 ## [Version 0.9.0] - 2025-06-08
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,22 +11,22 @@ repository = "https://github.com/rust-embedded-community/embedded-sdmmc-rs"
 version = "0.9.0"
 
 # Make sure to update the CI too!
-rust-version = "1.76"
+rust-version = "1.86"
 
 [dependencies]
 byteorder = {version = "1", default-features = false}
-defmt = {version = "0.3", optional = true}
+defmt = {version = "1.0.1", optional = true}
 embedded-hal = "1.0.0"
 embedded-io = "0.6.1"
-heapless = "^0.8"
+heapless = "0.9.1"
 log = {version = "0.4", default-features = false, optional = true}
 
 [dev-dependencies]
 chrono = "0.4"
-embedded-hal-bus = "0.2.0"
-env_logger = "0.10.0"
+embedded-hal-bus = "0.3.0"
+env_logger = "0.11.8"
 flate2 = "1.0"
-hex-literal = "0.4.1"
+hex-literal = "1.0.0"
 sha2 = "0.10"
 
 [features]

--- a/src/fat/bpb.rs
+++ b/src/fat/bpb.rs
@@ -20,7 +20,7 @@ impl<'a> Bpb<'a> {
     pub(crate) const FOOTER_VALUE: u16 = 0xAA55;
 
     /// Attempt to parse a Boot Parameter Block from a 512 byte sector.
-    pub fn create_from_bytes(data: &[u8; 512]) -> Result<Bpb, &'static str> {
+    pub fn create_from_bytes(data: &[u8; 512]) -> Result<Bpb<'_>, &'static str> {
         let mut bpb = Bpb {
             data,
             fat_type: FatType::Fat16,

--- a/src/fat/info.rs
+++ b/src/fat/info.rs
@@ -49,7 +49,7 @@ impl<'a> InfoSector<'a> {
     const TRAIL_SIG: u32 = 0xAA55_0000;
 
     /// Try and create a new Info Sector from a block.
-    pub fn create_from_bytes(data: &[u8; 512]) -> Result<InfoSector, &'static str> {
+    pub fn create_from_bytes(data: &[u8; 512]) -> Result<InfoSector<'_>, &'static str> {
         let info = InfoSector { data };
         if info.lead_sig() != Self::LEAD_SIG {
             return Err("Bad lead signature on InfoSector");

--- a/src/fat/ondiskdirentry.rs
+++ b/src/fat/ondiskdirentry.rs
@@ -57,7 +57,7 @@ impl<'a> OnDiskDirEntry<'a> {
 
     /// Create a new on-disk directory entry from a block of 32 bytes read
     /// from a directory file.
-    pub fn new(data: &[u8]) -> OnDiskDirEntry {
+    pub fn new(data: &[u8]) -> OnDiskDirEntry<'_> {
         OnDiskDirEntry { data }
     }
 

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -58,7 +58,7 @@ impl RawDirectory {
     >(
         self,
         volume_mgr: &VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
-    ) -> Directory<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+    ) -> Directory<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
     where
         D: crate::BlockDevice,
         T: crate::TimeSource,
@@ -113,7 +113,7 @@ where
     pub fn open_dir<N>(
         &self,
         name: N,
-    ) -> Result<Directory<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>>
+    ) -> Result<Directory<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>>
     where
         N: ToShortFileName,
     {
@@ -193,7 +193,7 @@ where
         &self,
         name: N,
         mode: crate::Mode,
-    ) -> Result<crate::File<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, crate::Error<D::Error>>
+    ) -> Result<crate::File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, crate::Error<D::Error>>
     where
         N: super::ToShortFileName,
     {

--- a/src/filesystem/files.rs
+++ b/src/filesystem/files.rs
@@ -30,7 +30,7 @@ impl RawFile {
     pub fn to_file<D, T, const MAX_DIRS: usize, const MAX_FILES: usize, const MAX_VOLUMES: usize>(
         self,
         volume_mgr: &VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
-    ) -> File<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+    ) -> File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
     where
         D: crate::BlockDevice,
         T: crate::TimeSource,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ impl RawVolume {
     >(
         self,
         volume_mgr: &VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
-    ) -> Volume<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+    ) -> Volume<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
     where
         D: crate::BlockDevice,
         T: crate::TimeSource,
@@ -346,7 +346,7 @@ where
     /// use `open_file_in_dir`.
     pub fn open_root_dir(
         &self,
-    ) -> Result<crate::Directory<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>> {
+    ) -> Result<crate::Directory<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>> {
         let d = self.volume_mgr.open_root_dir(self.raw_volume)?;
         Ok(d.to_directory(self.volume_mgr))
     }

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -110,7 +110,7 @@ where
     pub fn open_volume(
         &self,
         volume_idx: VolumeIdx,
-    ) -> Result<Volume<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>> {
+    ) -> Result<Volume<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>> {
         let v = self.open_raw_volume(volume_idx)?;
         Ok(v.to_volume(self))
     }


### PR DESCRIPTION
The upgrade from `heapless` 0.8.x to 0.9.x is particularly important for me, because I'm heavily using `heapless` in an embedded software project and need to use a single consistent version for interoperability. I took this opportunity to upgrade all other outdated dependencies too.

This raises the MSRV to 1.86.0. Testing has shown that this is the minimum required version for `heapless` 0.9.1.

CC @thejpster 