### PR TITLE
docs: adds esp32 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This repository houses no examples for no-std usage, however you can check out t
 * [Pi Pico](https://github.com/rp-rs/rp-hal-boards/blob/main/boards/rp-pico/examples/pico_spi_sd_card.rs)
 * [STM32H7XX](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/sdmmc_fat.rs)
 * [atsamd(pygamer)](https://github.com/atsamd-rs/atsamd/blob/master/boards/pygamer/examples/sd_card.rs)
+* [ESP32 (esp-hal + Embassy)](https://github.com/zpg6/esp32-sdcard)
 
 ## Todo List (PRs welcome!)
 


### PR DESCRIPTION
Adding an example of using on ESP32 with esp-hal (no_std) + Embassy: https://github.com/zpg6/esp32-sdcard

- Uses `esp-hal@1.0.0`
- Includes instructions for installing the `esp-rs` toolchain
- Gives some example Micro SD Card Reader/Adapter modules you can buy
- Shows how to format Micro SD Cards with Rufus
- Gives example debug and CSV file outputs created by the example