### PR TITLE
Fix CI - bump MSRV to 1.87

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # Always run MSRV too!
-        rust: ["stable", "1.86"]
+        rust: ["stable", "1.87"]
         features: ['log', 'defmt-log', '""']
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 ### Changed
 
 - Updated to `defmt` 1.0.1, `embedded-hal-bus` 0.3.0, `env_logger` 0.11.8, `heapless` 0.9.1, and `hex-literal` 1.0.0.
-- Raised the minimum supported Rust version to 1.86.0.
+- Raised the minimum supported Rust version to 1.87.0.
 
 ## [Version 0.9.0] - 2025-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 
 - Updated to `defmt` 1.0.1, `embedded-hal-bus` 0.3.0, `env_logger` 0.11.8, `heapless` 0.9.1, and `hex-literal` 1.0.0.
 - Raised the minimum supported Rust version to 1.87.0.
+- Removed `core-error` feature as MSRV is now above 1.81
 
 ## [Version 0.9.0] - 2025-06-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/rust-embedded-community/embedded-sdmmc-rs"
 version = "0.9.0"
 
 # Make sure to update the CI too!
-rust-version = "1.86"
+rust-version = "1.87"
 
 [dependencies]
 byteorder = {version = "1", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ sha2 = "0.10"
 default = ["log"]
 defmt-log = ["dep:defmt"]
 log = ["dep:log"]
-core-error = []
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,6 @@
 //! * `defmt-log`: By turning off the default features and enabling the
 //!   `defmt-log` feature you can configure this crate to log messages over defmt
 //!   instead.
-//! * `core-error`: Enables implementations of `core::error::Error` for all error
-//!   types. This raises the Minimum Supported Rust Version to 1.81.
 //!
 //! You cannot enable both the `log` feature and the `defmt-log` feature.
 
@@ -316,7 +314,6 @@ where
     }
 }
 
-#[cfg(feature = "core-error")]
 impl<E> core::error::Error for Error<E> where E: core::fmt::Debug + core::fmt::Display {}
 
 /// A handle to a volume.

--- a/src/sdcard/mod.rs
+++ b/src/sdcard/mod.rs
@@ -648,7 +648,6 @@ impl core::fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "core-error")]
 impl core::error::Error for Error {}
 
 /// The different types of card we support.


### PR DESCRIPTION
* Bumps MSRV to 1.87 to avoid failure seen in https://github.com/rust-embedded-community/embedded-sdmmc-rs/pull/210
* Removes core-error feature, because MSRV is high enough we can just always turn it on
