### PR TITLE
Update to edition 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 - Updated to `defmt` 1.0.1, `embedded-hal-bus` 0.3.0, `env_logger` 0.11.8, `heapless` 0.9.1, and `hex-literal` 1.0.0.
 - Raised the minimum supported Rust version to 1.87.0.
 - Removed `core-error` feature as MSRV is now above 1.81
+- Set edition to 2024
 
 ## [Version 0.9.0] - 2025-06-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>", "Rust Embedded Community Developers"]
 categories = ["embedded", "no-std"]
 description = "A basic SD/MMC driver for Embedded Rust."
-edition = "2021"
+edition = "2024"
 keywords = ["sdcard", "mmc", "embedded", "fat32"]
 license = "MIT OR Apache-2.0"
 name = "embedded-sdmmc"

--- a/examples/linux/mod.rs
+++ b/examples/linux/mod.rs
@@ -4,8 +4,8 @@ use chrono::Timelike;
 use embedded_sdmmc::{Block, BlockCount, BlockDevice, BlockIdx, TimeSource, Timestamp};
 use std::cell::RefCell;
 use std::fs::{File, OpenOptions};
-use std::io::prelude::*;
 use std::io::SeekFrom;
+use std::io::prelude::*;
 use std::path::Path;
 
 #[derive(Debug)]

--- a/src/fat/mod.rs
+++ b/src/fat/mod.rs
@@ -22,7 +22,7 @@ mod volume;
 pub use bpb::Bpb;
 pub use info::{Fat16Info, Fat32Info, FatSpecificInfo, InfoSector};
 pub use ondiskdirentry::OnDiskDirEntry;
-pub use volume::{parse_volume, FatVolume, VolumeName};
+pub use volume::{FatVolume, VolumeName, parse_volume};
 
 // ****************************************************************************
 //

--- a/src/fat/ondiskdirentry.rs
+++ b/src/fat/ondiskdirentry.rs
@@ -1,6 +1,6 @@
 //! Directory Entry as stored on-disk
 
-use crate::{fat::FatType, Attributes, BlockIdx, ClusterId, DirEntry, ShortFileName, Timestamp};
+use crate::{Attributes, BlockIdx, ClusterId, DirEntry, ShortFileName, Timestamp, fat::FatType};
 use byteorder::{ByteOrder, LittleEndian};
 
 /// A 32-byte directory entry as stored on-disk in a directory file.

--- a/src/fat/volume.rs
+++ b/src/fat/volume.rs
@@ -603,7 +603,7 @@ impl FatVolume {
                         lfn_buffer.push(&buffer);
                         SeqState::Complete { csum }
                     }
-                    (true, sequence, _) if sequence >= 0x02 && sequence < 0x14 => {
+                    (true, sequence, _) if (0x02..0x14).contains(&sequence) => {
                         lfn_buffer.clear();
                         lfn_buffer.push(&buffer);
                         SeqState::Remaining {
@@ -616,7 +616,7 @@ impl FatVolume {
                         SeqState::Complete { csum }
                     }
                     (false, sequence, SeqState::Remaining { csum, next })
-                        if sequence >= 0x01 && sequence < 0x13 && next == sequence =>
+                        if (0x01..0x13).contains(&sequence) && next == sequence =>
                     {
                         lfn_buffer.push(&buffer);
                         SeqState::Remaining {
@@ -767,10 +767,7 @@ impl FatVolume {
                     }
                 }
             }
-            current_cluster = match self.next_cluster(block_cache, cluster) {
-                Ok(n) => Some(n),
-                _ => None,
-            };
+            current_cluster = self.next_cluster(block_cache, cluster).ok();
         }
         Ok(())
     }
@@ -849,10 +846,7 @@ impl FatVolume {
                             x => return x,
                         }
                     }
-                    current_cluster = match self.next_cluster(block_cache, cluster) {
-                        Ok(n) => Some(n),
-                        _ => None,
-                    }
+                    current_cluster = self.next_cluster(block_cache, cluster).ok()
                 }
                 Err(Error::NotFound)
             }
@@ -974,10 +968,7 @@ impl FatVolume {
                         }
                     }
                     // Find the next cluster
-                    current_cluster = match self.next_cluster(block_cache, cluster) {
-                        Ok(n) => Some(n),
-                        _ => None,
-                    }
+                    current_cluster = self.next_cluster(block_cache, cluster).ok()
                 }
                 // Ok, give up
             }
@@ -1356,9 +1347,8 @@ where
                 return Err(Error::BadBlockSize(bpb.bytes_per_block()));
             }
             // FirstDataSector = BPB_ResvdSecCnt + (BPB_NumFATs * FATSz) + RootDirSectors;
-            let root_dir_blocks = ((u32::from(bpb.root_entries_count()) * OnDiskDirEntry::LEN_U32)
-                + (Block::LEN_U32 - 1))
-                / Block::LEN_U32;
+            let root_dir_blocks = (u32::from(bpb.root_entries_count()) * OnDiskDirEntry::LEN_U32)
+                .div_ceil(Block::LEN_U32);
             let first_root_dir_block =
                 fat_start + BlockCount(u32::from(bpb.num_fats()) * bpb.fat_size());
             let first_data_block = first_root_dir_block + BlockCount(root_dir_blocks);

--- a/src/fat/volume.rs
+++ b/src/fat/volume.rs
@@ -1,14 +1,14 @@
 //! FAT-specific volume support.
 
 use crate::{
-    debug,
+    Attributes, Block, BlockCache, BlockCount, BlockDevice, BlockIdx, ClusterId, DirEntry,
+    DirectoryInfo, Error, LfnBuffer, ShortFileName, TimeSource, VolumeType, debug,
     fat::{
         Bpb, Fat16Info, Fat32Info, FatSpecificInfo, FatType, InfoSector, OnDiskDirEntry,
         RESERVED_ENTRIES,
     },
     filesystem::FilenameError,
-    trace, warn, Attributes, Block, BlockCache, BlockCount, BlockDevice, BlockIdx, ClusterId,
-    DirEntry, DirectoryInfo, Error, LfnBuffer, ShortFileName, TimeSource, VolumeType,
+    trace, warn,
 };
 use byteorder::{ByteOrder, LittleEndian};
 use core::convert::TryFrom;
@@ -1036,8 +1036,7 @@ impl FatVolume {
                 while current_cluster.0 < end_cluster.0 {
                     trace!(
                         "current_cluster={:?}, end_cluster={:?}",
-                        current_cluster,
-                        end_cluster
+                        current_cluster, end_cluster
                     );
                     let fat_offset = current_cluster.0 * 2;
                     trace!("fat_offset = {:?}", fat_offset);
@@ -1066,8 +1065,7 @@ impl FatVolume {
                 while current_cluster.0 < end_cluster.0 {
                     trace!(
                         "current_cluster={:?}, end_cluster={:?}",
-                        current_cluster,
-                        end_cluster
+                        current_cluster, end_cluster
                     );
                     let fat_offset = current_cluster.0 * 4;
                     trace!("fat_offset = {:?}", fat_offset);
@@ -1115,8 +1113,7 @@ impl FatVolume {
         };
         trace!(
             "Finding next free between {:?}..={:?}",
-            start_cluster,
-            end_cluster
+            start_cluster, end_cluster
         );
         let new_cluster = match self.find_next_free_cluster(block_cache, start_cluster, end_cluster)
         {
@@ -1137,15 +1134,13 @@ impl FatVolume {
         if let Some(cluster) = prev_cluster {
             trace!(
                 "Updating old cluster {:?} to {:?} in FAT",
-                cluster,
-                new_cluster
+                cluster, new_cluster
             );
             self.update_fat(block_cache, cluster, new_cluster)?;
         }
         trace!(
             "Finding next free between {:?}..={:?}",
-            new_cluster,
-            end_cluster
+            new_cluster, end_cluster
         );
         self.next_free_cluster =
             match self.find_next_free_cluster(block_cache, new_cluster, end_cluster) {

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -255,7 +255,7 @@ where
     T: crate::TimeSource,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Directory({})", self.raw_directory.0 .0)
+        write!(f, "Directory({})", self.raw_directory.0.0)
     }
 }
 
@@ -267,7 +267,7 @@ where
     T: crate::TimeSource,
 {
     fn format(&self, fmt: defmt::Formatter) {
-        defmt::write!(fmt, "Directory({})", self.raw_directory.0 .0)
+        defmt::write!(fmt, "Directory({})", self.raw_directory.0.0)
     }
 }
 

--- a/src/filesystem/files.rs
+++ b/src/filesystem/files.rs
@@ -1,7 +1,7 @@
 use super::TimeSource;
 use crate::{
-    filesystem::{ClusterId, DirEntry, Handle},
     BlockDevice, Error, RawVolume, VolumeManager,
+    filesystem::{ClusterId, DirEntry, Handle},
 };
 use embedded_io::{ErrorType, Read, Seek, SeekFrom, Write};
 
@@ -163,28 +163,28 @@ where
     T: crate::TimeSource,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "File({})", self.raw_file.0 .0)
+        write!(f, "File({})", self.raw_file.0.0)
     }
 }
 
 impl<
-        D: BlockDevice,
-        T: TimeSource,
-        const MAX_DIRS: usize,
-        const MAX_FILES: usize,
-        const MAX_VOLUMES: usize,
-    > ErrorType for File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+    D: BlockDevice,
+    T: TimeSource,
+    const MAX_DIRS: usize,
+    const MAX_FILES: usize,
+    const MAX_VOLUMES: usize,
+> ErrorType for File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
 {
     type Error = crate::Error<D::Error>;
 }
 
 impl<
-        D: BlockDevice,
-        T: TimeSource,
-        const MAX_DIRS: usize,
-        const MAX_FILES: usize,
-        const MAX_VOLUMES: usize,
-    > Read for File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+    D: BlockDevice,
+    T: TimeSource,
+    const MAX_DIRS: usize,
+    const MAX_FILES: usize,
+    const MAX_VOLUMES: usize,
+> Read for File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         if buf.is_empty() {
@@ -196,12 +196,12 @@ impl<
 }
 
 impl<
-        D: BlockDevice,
-        T: TimeSource,
-        const MAX_DIRS: usize,
-        const MAX_FILES: usize,
-        const MAX_VOLUMES: usize,
-    > Write for File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+    D: BlockDevice,
+    T: TimeSource,
+    const MAX_DIRS: usize,
+    const MAX_FILES: usize,
+    const MAX_VOLUMES: usize,
+> Write for File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         if buf.is_empty() {
@@ -218,12 +218,12 @@ impl<
 }
 
 impl<
-        D: BlockDevice,
-        T: TimeSource,
-        const MAX_DIRS: usize,
-        const MAX_FILES: usize,
-        const MAX_VOLUMES: usize,
-    > Seek for File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
+    D: BlockDevice,
+    T: TimeSource,
+    const MAX_DIRS: usize,
+    const MAX_FILES: usize,
+    const MAX_VOLUMES: usize,
+> Seek for File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>
 {
     fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
         match pos {
@@ -249,7 +249,7 @@ where
     T: crate::TimeSource,
 {
     fn format(&self, fmt: defmt::Formatter) {
-        defmt::write!(fmt, "File({})", self.raw_file.0 .0)
+        defmt::write!(fmt, "File({})", self.raw_file.0.0)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,8 @@ pub use crate::fat::{FatVolume, VolumeName};
 
 #[doc(inline)]
 pub use crate::filesystem::{
-    Attributes, ClusterId, DirEntry, Directory, File, FilenameError, LfnBuffer, Mode, RawDirectory,
-    RawFile, ShortFileName, TimeSource, Timestamp, MAX_FILE_SIZE,
+    Attributes, ClusterId, DirEntry, Directory, File, FilenameError, LfnBuffer, MAX_FILE_SIZE,
+    Mode, RawDirectory, RawFile, ShortFileName, TimeSource, Timestamp,
 };
 
 use filesystem::DirectoryInfo;
@@ -431,7 +431,7 @@ where
     T: crate::TimeSource,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Volume({})", self.raw_volume.0 .0)
+        write!(f, "Volume({})", self.raw_volume.0.0)
     }
 }
 
@@ -443,7 +443,7 @@ where
     T: crate::TimeSource,
 {
     fn format(&self, fmt: defmt::Formatter) {
-        defmt::write!(fmt, "Volume({})", self.raw_volume.0 .0)
+        defmt::write!(fmt, "Volume({})", self.raw_volume.0.0)
     }
 }
 

--- a/src/sdcard/mod.rs
+++ b/src/sdcard/mod.rs
@@ -5,7 +5,7 @@
 
 pub mod proto;
 
-use crate::{trace, Block, BlockCount, BlockDevice, BlockIdx};
+use crate::{Block, BlockCount, BlockDevice, BlockIdx, trace};
 use core::cell::RefCell;
 use proto::*;
 

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -10,14 +10,15 @@ use byteorder::{ByteOrder, LittleEndian};
 use heapless::Vec;
 
 use crate::{
+    Block, BlockCache, BlockCount, BlockDevice, BlockIdx, Error, PARTITION_ID_FAT16,
+    PARTITION_ID_FAT16_LBA, PARTITION_ID_FAT16_SMALL, PARTITION_ID_FAT32_CHS_LBA,
+    PARTITION_ID_FAT32_LBA, RawVolume, ShortFileName, Volume, VolumeIdx, VolumeInfo, VolumeType,
     debug, fat,
     filesystem::{
-        Attributes, ClusterId, DirEntry, DirectoryInfo, FileInfo, HandleGenerator, LfnBuffer, Mode,
-        RawDirectory, RawFile, TimeSource, ToShortFileName, MAX_FILE_SIZE,
+        Attributes, ClusterId, DirEntry, DirectoryInfo, FileInfo, HandleGenerator, LfnBuffer,
+        MAX_FILE_SIZE, Mode, RawDirectory, RawFile, TimeSource, ToShortFileName,
     },
-    trace, Block, BlockCache, BlockCount, BlockDevice, BlockIdx, Error, RawVolume, ShortFileName,
-    Volume, VolumeIdx, VolumeInfo, VolumeType, PARTITION_ID_FAT16, PARTITION_ID_FAT16_LBA,
-    PARTITION_ID_FAT16_SMALL, PARTITION_ID_FAT32_CHS_LBA, PARTITION_ID_FAT32_LBA,
+    trace,
 };
 
 /// Wraps a block device and gives access to the FAT-formatted volumes within
@@ -1245,8 +1246,8 @@ fn solve_mode_variant(mode: Mode, dir_entry_is_some: bool) -> Mode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::filesystem::Handle;
     use crate::Timestamp;
+    use crate::filesystem::Handle;
 
     struct DummyBlockDevice;
 

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -100,8 +100,8 @@ where
         F: FnOnce(&mut D) -> R,
     {
         let mut data = self.data.borrow_mut();
-        let result = f(data.block_cache.block_device());
-        result
+
+        f(data.block_cache.block_device())
     }
 
     /// Get a volume (or partition) based on entries in the Master Boot Record.
@@ -724,7 +724,7 @@ where
             if maybe_volume_name.is_none()
                 && de.attributes == Attributes::create_from_fat(Attributes::VOLUME)
             {
-                maybe_volume_name = Some(unsafe { de.name.clone().to_volume_label() })
+                maybe_volume_name = Some(unsafe { de.name.to_volume_label() })
             }
         })?;
 

--- a/tests/directories.rs
+++ b/tests/directories.rs
@@ -578,9 +578,11 @@ fn make_directory() {
         .open_root_dir(fat32_volume)
         .expect("open root dir");
     // Check we can't make it again now it exists
-    assert!(volume_mgr
-        .make_dir_in_dir(root_dir, &test_dir_name)
-        .is_err());
+    assert!(
+        volume_mgr
+            .make_dir_in_dir(root_dir, &test_dir_name)
+            .is_err()
+    );
     let new_dir = volume_mgr
         .open_dir(root_dir, &test_dir_name)
         .expect("find new dir");


### PR DESCRIPTION
To adapt to new formatting defaults and avoid clippy warnings, this includes changes made by `cargo fmt` and `cargo clippy --fix`.

Overall, I think the clippy fixes are an improvement. I'm not 100% sure about `clippy::manual_range_contains`. Which one is more readable?

```
    (true, sequence, _) if sequence >= 0x02 && sequence < 0x14 => {
```
or
```
    (true, sequence, _) if (0x02..0x14).contains(&sequence) => {
```

To me the old version looks more familiar. But I tend to agree with the reasoning given at https://rust-lang.github.io/rust-clippy/beta/index.html#manual_range_contains. In case there is no consensus on that change, we could also disable that lint instead.

This also fixes #212.

