### PR TITLE
Allow `close_volume()` to complete even if updating the info sector fails

### DIFF
--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -915,8 +915,8 @@ where
 
     /// Close a file with the given raw file handle.
     ///
-    /// If the flush operation fails, the file is closed anyway and the
-    /// resulting error is returned.
+    /// Attempts to flush the file before closing, if necessary. If the flush
+    /// fails, the file is closed anyway and the resulting error is returned.
     pub fn close_file(&self, file: RawFile) -> Result<(), Error<D::Error>> {
         let flush_result = self.flush_file(file);
         let mut data = self.data.try_borrow_mut().map_err(|_| Error::LockError)?;

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -352,15 +352,13 @@ where
 
         let volume_idx = data.get_volume_by_id(volume)?;
 
-        match &mut data.open_volumes[volume_idx].volume_type {
-            VolumeType::Fat(fat) => {
-                fat.update_info_sector(&mut data.block_cache)?;
-            }
-        }
+        let update_result = match &mut data.open_volumes[volume_idx].volume_type {
+            VolumeType::Fat(fat) => fat.update_info_sector(&mut data.block_cache),
+        };
 
         data.open_volumes.swap_remove(volume_idx);
 
-        Ok(())
+        update_result
     }
 
     /// Look in a directory for a named file.

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -331,9 +331,12 @@ where
         Err(Error::BadHandle)
     }
 
-    /// Close a volume
+    /// Close a volume.
     ///
     /// You can't close it if there are any files or directories open on it.
+    ///
+    /// If the info sector update (which is non-critical) fails, the volume is
+    /// closed anyway and the resulting error is returned.
     pub fn close_volume(&self, volume: RawVolume) -> Result<(), Error<D::Error>> {
         let mut data = self.data.try_borrow_mut().map_err(|_| Error::LockError)?;
         let data = data.deref_mut();
@@ -911,6 +914,9 @@ where
     }
 
     /// Close a file with the given raw file handle.
+    ///
+    /// If the flush operation fails, the file is closed anyway and the
+    /// resulting error is returned.
     pub fn close_file(&self, file: RawFile) -> Result<(), Error<D::Error>> {
         let flush_result = self.flush_file(file);
         let mut data = self.data.try_borrow_mut().map_err(|_| Error::LockError)?;


### PR DESCRIPTION
Resolves #207. Modifies `close_volume()` slightly to continue with closing the volume even if updating the info sector (which is non-critical as detailed in the issue) fails. The resulting error is returned after the volume is closed. With this, `close_volume()` now does the same as `close_file()` (which closes the file even if the flush operation fails).

I also added to the documentation for both `close_volume()` and `close_file()` to detail this behaviour of continuing even if the write fails.