### PR TITLE
Support opening files by long file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
 - Set edition to 2024
 - Removed `Error::DeleteDirAsFile` (breaking change)
 - Renamed `delete_file_in_dir` to `delete_entry_in_dir` because it can now delete empty directories (breaking change)
+- Added `open_long_name_file_in_dir` API, to open files using their Long File Name
+- Updated directory iterator callback, to allow bailing out early (breaking change)
 
 ## [Version 0.9.0] - 2025-06-08
 

--- a/examples/list_dir.rs
+++ b/examples/list_dir.rs
@@ -79,6 +79,7 @@ fn list_dir(directory: Directory<'_>, path: &str) -> Result<(), Error> {
         {
             children.push(entry.name.clone());
         }
+        embedded_sdmmc::Continue::Yes
     })?;
     for child_name in children {
         let child_dir = directory.open_dir(&child_name)?;

--- a/examples/shell.rs
+++ b/examples/shell.rs
@@ -340,7 +340,7 @@ impl Context {
     /// print a text file
     fn cat(&self, filename: &Path) -> Result<(), Error> {
         let (dir, filename) = self.resolve_filename(filename)?;
-        let f = dir.open_file_in_dir(filename, Mode::ReadOnly)?;
+        let f = dir.open_long_name_file_in_dir(filename, Mode::ReadOnly)?;
         let mut data = Vec::new();
         while !f.is_eof() {
             let mut buffer = vec![0u8; 65536];
@@ -360,7 +360,7 @@ impl Context {
     /// print a binary file
     fn hexdump(&self, filename: &Path) -> Result<(), Error> {
         let (dir, filename) = self.resolve_filename(filename)?;
-        let f = dir.open_file_in_dir(filename, Mode::ReadOnly)?;
+        let f = dir.open_long_name_file_in_dir(filename, Mode::ReadOnly)?;
         let mut data = Vec::new();
         while !f.is_eof() {
             let mut buffer = vec![0u8; 65536];

--- a/examples/shell.rs
+++ b/examples/shell.rs
@@ -264,6 +264,7 @@ impl Context {
                     println!();
                 }
             }
+            embedded_sdmmc::Continue::Yes
         })?;
         Ok(())
     }
@@ -292,6 +293,7 @@ impl Context {
             {
                 children.push(entry.name.clone());
             }
+            embedded_sdmmc::Continue::Yes
         })?;
         for child in children {
             println!("Entering {}", child);

--- a/src/fat/volume.rs
+++ b/src/fat/volume.rs
@@ -1,8 +1,8 @@
 //! FAT-specific volume support.
 
 use crate::{
-    Attributes, Block, BlockCache, BlockCount, BlockDevice, BlockIdx, ClusterId, DirEntry,
-    DirectoryInfo, Error, LfnBuffer, ShortFileName, TimeSource, VolumeType, debug,
+    Attributes, Block, BlockCache, BlockCount, BlockDevice, BlockIdx, ClusterId, Continue,
+    DirEntry, DirectoryInfo, Error, LfnBuffer, ShortFileName, TimeSource, VolumeType, debug,
     fat::{
         Bpb, Fat16Info, Fat32Info, FatSpecificInfo, FatType, InfoSector, OnDiskDirEntry,
         RESERVED_ENTRIES,
@@ -546,7 +546,7 @@ impl FatVolume {
         mut func: F,
     ) -> Result<(), Error<D::Error>>
     where
-        F: FnMut(&DirEntry),
+        F: FnMut(&DirEntry) -> Continue,
         D: BlockDevice,
     {
         match &self.fat_specific_info {
@@ -571,7 +571,7 @@ impl FatVolume {
         mut func: F,
     ) -> Result<(), Error<D::Error>>
     where
-        F: FnMut(&DirEntry, Option<&str>),
+        F: FnMut(&DirEntry, Option<&str>) -> Continue,
         D: BlockDevice,
     {
         #[derive(Clone, Copy)]
@@ -639,6 +639,7 @@ impl FatVolume {
                 self.iterate_fat16(dir_info, fat16_info, block_cache, |de, odde| {
                     if let Some((start, this_seqno, csum, buffer)) = odde.lfn_contents() {
                         seq_state = seq_state.update(lfn_buffer, start, this_seqno, csum, buffer);
+                        Continue::Yes
                     } else if let SeqState::Complete { csum } = seq_state {
                         if csum == de.name.csum() {
                             // Checksum is good, and all the pieces are there
@@ -656,6 +657,7 @@ impl FatVolume {
                 self.iterate_fat32(dir_info, fat32_info, block_cache, |de, odde| {
                     if let Some((start, this_seqno, csum, buffer)) = odde.lfn_contents() {
                         seq_state = seq_state.update(lfn_buffer, start, this_seqno, csum, buffer);
+                        Continue::Yes
                     } else if let SeqState::Complete { csum } = seq_state {
                         if csum == de.name.csum() {
                             // Checksum is good, and all the pieces are there
@@ -680,7 +682,7 @@ impl FatVolume {
         mut func: F,
     ) -> Result<(), Error<D::Error>>
     where
-        F: for<'odde> FnMut(&DirEntry, &OnDiskDirEntry<'odde>),
+        F: for<'odde> FnMut(&DirEntry, &OnDiskDirEntry<'odde>) -> Continue,
         D: BlockDevice,
     {
         // Root directories on FAT16 have a fixed size, because they use
@@ -700,7 +702,7 @@ impl FatVolume {
             _ => BlockCount(u32::from(self.blocks_per_cluster)),
         };
 
-        while let Some(cluster) = current_cluster {
+        'outer: while let Some(cluster) = current_cluster {
             for block_idx in first_dir_block_num.range(dir_size) {
                 trace!("Reading FAT");
                 let block = block_cache.read(block_idx)?;
@@ -708,12 +710,14 @@ impl FatVolume {
                     let dir_entry = OnDiskDirEntry::new(dir_entry_bytes);
                     if dir_entry.is_end() {
                         // Can quit early
-                        return Ok(());
+                        break 'outer;
                     } else if dir_entry.is_valid() {
                         // Safe, since Block::LEN always fits on a u32
                         let start = (i * OnDiskDirEntry::LEN) as u32;
                         let entry = dir_entry.get_entry(FatType::Fat16, block_idx, start);
-                        func(&entry, &dir_entry);
+                        if func(&entry, &dir_entry) == Continue::No {
+                            break 'outer;
+                        }
                     }
                 }
             }
@@ -740,7 +744,7 @@ impl FatVolume {
         mut func: F,
     ) -> Result<(), Error<D::Error>>
     where
-        F: for<'odde> FnMut(&DirEntry, &OnDiskDirEntry<'odde>),
+        F: for<'odde> FnMut(&DirEntry, &OnDiskDirEntry<'odde>) -> Continue,
         D: BlockDevice,
     {
         // All directories on FAT32 have a cluster chain but the root

--- a/src/fat/volume.rs
+++ b/src/fat/volume.rs
@@ -559,6 +559,27 @@ impl FatVolume {
         }
     }
 
+    /// Calls callback `func` with every valid entry in the given directory, plus its ODDE.
+    fn iterate_dir_internal<D, F>(
+        &self,
+        block_cache: &mut BlockCache<D>,
+        dir_info: &DirectoryInfo,
+        func: F,
+    ) -> Result<(), Error<D::Error>>
+    where
+        F: FnMut(&DirEntry, &OnDiskDirEntry) -> Continue,
+        D: BlockDevice,
+    {
+        match &self.fat_specific_info {
+            FatSpecificInfo::Fat16(fat16_info) => {
+                self.iterate_fat16(dir_info, fat16_info, block_cache, func)
+            }
+            FatSpecificInfo::Fat32(fat32_info) => {
+                self.iterate_fat32(dir_info, fat32_info, block_cache, func)
+            }
+        }
+    }
+
     /// Calls callback `func` with every valid entry in the given directory,
     /// including the Long File Name.
     ///
@@ -634,44 +655,22 @@ impl FatVolume {
         }
 
         let mut seq_state = SeqState::Waiting;
-        match &self.fat_specific_info {
-            FatSpecificInfo::Fat16(fat16_info) => {
-                self.iterate_fat16(dir_info, fat16_info, block_cache, |de, odde| {
-                    if let Some((start, this_seqno, csum, buffer)) = odde.lfn_contents() {
-                        seq_state = seq_state.update(lfn_buffer, start, this_seqno, csum, buffer);
-                        Continue::Yes
-                    } else if let SeqState::Complete { csum } = seq_state {
-                        if csum == de.name.csum() {
-                            // Checksum is good, and all the pieces are there
-                            func(de, Some(lfn_buffer.as_str()))
-                        } else {
-                            // Checksum was bad
-                            func(de, None)
-                        }
-                    } else {
-                        func(de, None)
-                    }
-                })
+        self.iterate_dir_internal(block_cache, dir_info, |de, odde| {
+            if let Some((start, this_seqno, csum, buffer)) = odde.lfn_contents() {
+                seq_state = seq_state.update(lfn_buffer, start, this_seqno, csum, buffer);
+                Continue::Yes
+            } else if let SeqState::Complete { csum } = seq_state {
+                if csum == de.name.csum() {
+                    // Checksum is good, and all the pieces are there
+                    func(de, Some(lfn_buffer.as_str()))
+                } else {
+                    // Checksum was bad
+                    func(de, None)
+                }
+            } else {
+                func(de, None)
             }
-            FatSpecificInfo::Fat32(fat32_info) => {
-                self.iterate_fat32(dir_info, fat32_info, block_cache, |de, odde| {
-                    if let Some((start, this_seqno, csum, buffer)) = odde.lfn_contents() {
-                        seq_state = seq_state.update(lfn_buffer, start, this_seqno, csum, buffer);
-                        Continue::Yes
-                    } else if let SeqState::Complete { csum } = seq_state {
-                        if csum == de.name.csum() {
-                            // Checksum is good, and all the pieces are there
-                            func(de, Some(lfn_buffer.as_str()))
-                        } else {
-                            // Checksum was bad
-                            func(de, None)
-                        }
-                    } else {
-                        func(de, None)
-                    }
-                })
-            }
-        }
+        })
     }
 
     fn iterate_fat16<D, F>(
@@ -786,103 +785,16 @@ impl FatVolume {
     where
         D: BlockDevice,
     {
-        match &self.fat_specific_info {
-            FatSpecificInfo::Fat16(fat16_info) => {
-                // Root directories on FAT16 have a fixed size, because they use
-                // a specially reserved space on disk (see
-                // `first_root_dir_block`). Other directories can have any size
-                // as they are made of regular clusters.
-                let mut current_cluster = Some(dir_info.cluster);
-                let mut first_dir_block_num = match dir_info.cluster {
-                    ClusterId::ROOT_DIR => self.lba_start + fat16_info.first_root_dir_block,
-                    _ => self.cluster_to_block(dir_info.cluster),
-                };
-                let dir_size = match dir_info.cluster {
-                    ClusterId::ROOT_DIR => {
-                        let len_bytes =
-                            u32::from(fat16_info.root_entries_count) * OnDiskDirEntry::LEN_U32;
-                        BlockCount::from_bytes(len_bytes)
-                    }
-                    _ => BlockCount(u32::from(self.blocks_per_cluster)),
-                };
-
-                while let Some(cluster) = current_cluster {
-                    for block in first_dir_block_num.range(dir_size) {
-                        match self.find_entry_in_block(
-                            block_cache,
-                            FatType::Fat16,
-                            match_name,
-                            block,
-                        ) {
-                            Err(Error::NotFound) => continue,
-                            x => return x,
-                        }
-                    }
-                    if cluster != ClusterId::ROOT_DIR {
-                        current_cluster = match self.next_cluster(block_cache, cluster) {
-                            Ok(n) => {
-                                first_dir_block_num = self.cluster_to_block(n);
-                                Some(n)
-                            }
-                            _ => None,
-                        };
-                    } else {
-                        current_cluster = None;
-                    }
-                }
-                Err(Error::NotFound)
+        let mut result = Err(Error::NotFound);
+        self.iterate_dir(block_cache, dir_info, |de| {
+            if de.name == *match_name {
+                result = Ok(de.clone());
+                Continue::No
+            } else {
+                Continue::Yes
             }
-            FatSpecificInfo::Fat32(fat32_info) => {
-                let mut current_cluster = match dir_info.cluster {
-                    ClusterId::ROOT_DIR => Some(fat32_info.first_root_dir_cluster),
-                    _ => Some(dir_info.cluster),
-                };
-                while let Some(cluster) = current_cluster {
-                    let block_idx = self.cluster_to_block(cluster);
-                    for block in block_idx.range(BlockCount(u32::from(self.blocks_per_cluster))) {
-                        match self.find_entry_in_block(
-                            block_cache,
-                            FatType::Fat32,
-                            match_name,
-                            block,
-                        ) {
-                            Err(Error::NotFound) => continue,
-                            x => return x,
-                        }
-                    }
-                    current_cluster = self.next_cluster(block_cache, cluster).ok()
-                }
-                Err(Error::NotFound)
-            }
-        }
-    }
-
-    /// Finds an entry in a given block of directory entries.
-    fn find_entry_in_block<D>(
-        &self,
-        block_cache: &mut BlockCache<D>,
-        fat_type: FatType,
-        match_name: &ShortFileName,
-        block_idx: BlockIdx,
-    ) -> Result<DirEntry, Error<D::Error>>
-    where
-        D: BlockDevice,
-    {
-        trace!("Reading directory");
-        let block = block_cache.read(block_idx).map_err(Error::DeviceError)?;
-        for (i, dir_entry_bytes) in block.chunks_exact(OnDiskDirEntry::LEN).enumerate() {
-            let dir_entry = OnDiskDirEntry::new(dir_entry_bytes);
-            if dir_entry.is_end() {
-                // Can quit early
-                break;
-            } else if dir_entry.matches(match_name) {
-                // Found it
-                // Block::LEN always fits on a u32
-                let start = (i * OnDiskDirEntry::LEN) as u32;
-                return Ok(dir_entry.get_entry(fat_type, block_idx, start));
-            }
-        }
-        Err(Error::NotFound)
+        })?;
+        result
     }
 
     /// Delete an entry from the given directory

--- a/src/fat/volume.rs
+++ b/src/fat/volume.rs
@@ -828,6 +828,9 @@ impl FatVolume {
                     debug!("Am waiting for LFN start");
                     let mut remaining = match_name;
                     if let Some((true, sequence, csum, buffer)) = odde.lfn_contents() {
+                        #[cfg(feature = "defmt-log")]
+                        debug!("{:02x} {:02x} {:04x}", sequence, csum, buffer);
+                        #[cfg(feature = "log")]
                         debug!("{:02x} {:02x} {:04x?}", sequence, csum, buffer);
                         // trim padding and NUL words off the end of the file name (which is the part that comes first)
                         for word in buffer
@@ -879,6 +882,9 @@ impl FatVolume {
                     );
                     let mut remaining = remaining;
                     if let Some((false, this_sequence, this_csum, buffer)) = odde.lfn_contents() {
+                        #[cfg(feature = "defmt-log")]
+                        debug!("{:02x} {:02x} {:04x}", sequence, csum, buffer);
+                        #[cfg(feature = "log")]
                         debug!("{:02x} {:02x} {:04x?}", sequence, csum, buffer);
                         if (this_sequence != sequence) || (this_csum != csum) {
                             // not what we wanted
@@ -928,7 +934,7 @@ impl FatVolume {
                         result = Ok(de.clone());
                         return Continue::No;
                     } else {
-                        debug!("Bad csum {:02x} != {:02x}", calc_csum, csum)
+                        debug!("Bad csum {:02x} != {:02x}", calc_csum, csum);
                     }
                 }
             }

--- a/src/fat/volume.rs
+++ b/src/fat/volume.rs
@@ -797,6 +797,146 @@ impl FatVolume {
         result
     }
 
+    /// Get an entry from the given directory
+    pub(crate) fn find_directory_entry_by_lfn<D>(
+        &self,
+        block_cache: &mut BlockCache<D>,
+        dir_info: &DirectoryInfo,
+        match_name: &str,
+    ) -> Result<DirEntry, Error<D::Error>>
+    where
+        D: BlockDevice,
+    {
+        let mut result = Err(Error::NotFound);
+        enum SeqState<'a> {
+            /// Looking for the first entry in an LFN sequence
+            Waiting,
+            /// Scanning through an LFN sequence
+            Scanning {
+                remaining: &'a str,
+                sequence: u8,
+                csum: u8,
+            },
+            /// Found an entry we like
+            Found { csum: u8 },
+        }
+
+        let mut state = SeqState::Waiting;
+        self.iterate_dir_internal(block_cache, dir_info, |de, odde| {
+            match state {
+                SeqState::Waiting => {
+                    debug!("Am waiting for LFN start");
+                    let mut remaining = match_name;
+                    if let Some((true, sequence, csum, buffer)) = odde.lfn_contents() {
+                        debug!("{:02x} {:02x} {:04x?}", sequence, csum, buffer);
+                        // trim padding and NUL words off the end of the file name (which is the part that comes first)
+                        for word in buffer
+                            .iter()
+                            .rev()
+                            .skip_while(|b| **b == 0xFFFF)
+                            .skip_while(|b| **b == 0x0000)
+                        {
+                            debug!("Looking at word {:04x}", *word);
+                            // UCS-2 16-bit values are valid Unicode code points - we do not expect surrogate pairs but if we find then, we give up.
+                            let Some(c) = char::from_u32(*word as u32) else {
+                                return Continue::Yes;
+                            };
+                            debug!("Looking at char '{}'", c);
+                            let Some(r) = remaining.strip_suffix(c) else {
+                                debug!("No, didn't want that");
+                                return Continue::Yes;
+                            };
+                            debug!("Liked it! {:?} is left", r);
+                            remaining = r;
+                        }
+                        if sequence == 1 {
+                            // last piece
+                            if remaining.is_empty() {
+                                // found it
+                                state = SeqState::Found { csum }
+                            } else {
+                                // no, we have characters left over
+                                state = SeqState::Waiting
+                            }
+                        } else {
+                            // keep looking
+                            state = SeqState::Scanning {
+                                remaining,
+                                sequence: sequence - 1,
+                                csum,
+                            };
+                        }
+                    }
+                }
+                SeqState::Scanning {
+                    remaining,
+                    sequence,
+                    csum,
+                } => {
+                    debug!(
+                        "Am waiting for more LFN sequence={:02x}, csum={:02x}",
+                        sequence, csum
+                    );
+                    let mut remaining = remaining;
+                    if let Some((false, this_sequence, this_csum, buffer)) = odde.lfn_contents() {
+                        debug!("{:02x} {:02x} {:04x?}", sequence, csum, buffer);
+                        if (this_sequence != sequence) || (this_csum != csum) {
+                            // not what we wanted
+                            debug!(
+                                "No! Got sequence={:02x}, csum={:02x}",
+                                this_sequence, this_csum
+                            );
+                            state = SeqState::Waiting;
+                            return Continue::Yes;
+                        }
+                        for word in buffer.iter().rev() {
+                            // UCS-2 16-bit values are valid Unicode code points - we do not expect surrogate pairs but if we find then, we give up.
+                            debug!("Looking at word {:04x}", *word);
+                            let Some(c) = char::from_u32(*word as u32) else {
+                                return Continue::Yes;
+                            };
+                            debug!("Looking at char '{}'", c);
+                            let Some(r) = remaining.strip_suffix(c) else {
+                                debug!("No, didn't want that");
+                                return Continue::Yes;
+                            };
+                            debug!("Liked it! {:?} is left", r);
+                            remaining = r;
+                        }
+                        if sequence == 1 {
+                            // last piece
+                            if remaining.is_empty() {
+                                // found it
+                                state = SeqState::Found { csum }
+                            } else {
+                                // no, we have characters left over
+                                state = SeqState::Waiting
+                            }
+                        } else {
+                            // keep looking
+                            state = SeqState::Scanning {
+                                remaining,
+                                sequence: sequence - 1,
+                                csum,
+                            };
+                        }
+                    }
+                }
+                SeqState::Found { csum } => {
+                    let calc_csum = de.name.csum();
+                    if calc_csum == csum {
+                        result = Ok(de.clone());
+                        return Continue::No;
+                    } else {
+                        debug!("Bad csum {:02x} != {:02x}", calc_csum, csum)
+                    }
+                }
+            }
+            Continue::Yes
+        })?;
+        result
+    }
+
     /// Delete an entry from the given directory
     pub(crate) fn delete_directory_entry<D>(
         &self,

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -197,6 +197,22 @@ where
         Ok(f.to_file(self.volume_mgr))
     }
 
+    /// Open a file.
+    ///
+    /// See [`VolumeManager::open_long_name_file_in_dir`] for details, except the
+    /// directory given is this directory.
+    pub fn open_long_name_file_in_dir(
+        &self,
+        name: &str,
+        mode: crate::Mode,
+    ) -> Result<crate::File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, crate::Error<D::Error>>
+    {
+        let f = self
+            .volume_mgr
+            .open_long_name_file_in_dir(self.raw_directory, name, mode)?;
+        Ok(f.to_file(self.volume_mgr))
+    }
+
     /// Delete a file/directory.
     ///
     /// See [`VolumeManager::delete_entry_in_dir`] for details, except the

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -1,7 +1,7 @@
 use crate::blockdevice::BlockIdx;
 use crate::fat::{FatType, OnDiskDirEntry};
 use crate::filesystem::{Attributes, ClusterId, Handle, LfnBuffer, ShortFileName, Timestamp};
-use crate::{Error, RawVolume, VolumeManager};
+use crate::{Continue, Error, RawVolume, VolumeManager};
 
 use super::ToShortFileName;
 
@@ -157,7 +157,7 @@ where
     /// given is this directory.
     pub fn iterate_dir<F>(&self, func: F) -> Result<(), Error<D::Error>>
     where
-        F: FnMut(&DirEntry),
+        F: FnMut(&DirEntry) -> Continue,
     {
         self.volume_mgr.iterate_dir(self.raw_directory, func)
     }
@@ -173,7 +173,7 @@ where
         func: F,
     ) -> Result<(), Error<D::Error>>
     where
-        F: FnMut(&DirEntry, Option<&str>),
+        F: FnMut(&DirEntry, Option<&str>) -> Continue,
     {
         self.volume_mgr
             .iterate_dir_lfn(self.raw_directory, lfn_buffer, func)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,6 +475,15 @@ pub enum VolumeType {
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct VolumeIdx(pub usize);
 
+/// Whether the callback should continue
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Continue {
+    /// Yes, give me more directories
+    Yes,
+    /// No, I've had enough
+    No,
+}
+
 /// Marker for a FAT32 partition. Sometimes also use for FAT16 formatted
 /// partitions.
 const PARTITION_ID_FAT32_LBA: u8 = 0x0C;

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -10,7 +10,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use heapless::Vec;
 
 use crate::{
-    Block, BlockCache, BlockCount, BlockDevice, BlockIdx, Error, PARTITION_ID_FAT16,
+    Block, BlockCache, BlockCount, BlockDevice, BlockIdx, Continue, Error, PARTITION_ID_FAT16,
     PARTITION_ID_FAT16_LBA, PARTITION_ID_FAT16_SMALL, PARTITION_ID_FAT32_CHS_LBA,
     PARTITION_ID_FAT32_LBA, RawVolume, ShortFileName, Volume, VolumeIdx, VolumeInfo, VolumeType,
     debug, fat,
@@ -465,7 +465,7 @@ where
         mut func: F,
     ) -> Result<(), Error<D::Error>>
     where
-        F: FnMut(&DirEntry),
+        F: FnMut(&DirEntry) -> Continue,
     {
         let mut data = self.data.try_borrow_mut().map_err(|_| Error::LockError)?;
         let data = data.deref_mut();
@@ -480,7 +480,9 @@ where
                     |de| {
                         // Hide all the LFN directory entries
                         if !de.attributes.is_lfn() {
-                            func(de);
+                            func(de)
+                        } else {
+                            Continue::Yes
                         }
                     },
                 )
@@ -515,7 +517,7 @@ where
         func: F,
     ) -> Result<(), Error<D::Error>>
     where
-        F: FnMut(&DirEntry, Option<&str>),
+        F: FnMut(&DirEntry, Option<&str>) -> Continue,
     {
         let mut data = self.data.try_borrow_mut().map_err(|_| Error::LockError)?;
         let data = data.deref_mut();
@@ -783,6 +785,7 @@ where
                         {
                             count += 1;
                         }
+                        Continue::Yes
                     })?;
                 }
             }
@@ -835,7 +838,10 @@ where
             if maybe_volume_name.is_none()
                 && de.attributes == Attributes::create_from_fat(Attributes::VOLUME)
             {
-                maybe_volume_name = Some(unsafe { de.name.to_volume_label() })
+                maybe_volume_name = Some(unsafe { de.name.to_volume_label() });
+                Continue::No
+            } else {
+                Continue::Yes
             }
         })?;
 

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -731,6 +731,158 @@ where
         }
     }
 
+    /// Open a file with the given Unicode long file name, in the given directory.
+    ///
+    /// You can only open existing long-file-name files - you cannot create them.
+    ///
+    /// <div class="warning">
+    ///
+    /// This function gives you a [`RawFile`] and when you are finished with
+    /// it, you **must** close the file by calling
+    /// [`VolumeManager::close_file`] otherwise you will leak internal
+    /// resources and/or suffer file-system corruption and data loss.
+    ///
+    /// </div>
+    ///
+    /// If you want a file handle that closes itself on drop, see
+    /// [`File`](crate::File).
+    pub fn open_long_name_file_in_dir(
+        &self,
+        directory: RawDirectory,
+        name: &str,
+        mode: Mode,
+    ) -> Result<RawFile, Error<D::Error>> {
+        let mut data = self.data.try_borrow_mut().map_err(|_| Error::LockError)?;
+        let data = data.deref_mut();
+
+        // This check is load-bearing - we do an unchecked push later.
+        if data.open_files.is_full() {
+            return Err(Error::TooManyOpenFiles);
+        }
+
+        let directory_idx = data.get_dir_by_id(directory)?;
+        let volume_id = data.open_dirs[directory_idx].raw_volume;
+        let volume_idx = data.get_volume_by_id(volume_id)?;
+        let volume_info = &data.open_volumes[volume_idx];
+
+        let dir_entry = match &volume_info.volume_type {
+            VolumeType::Fat(fat) => fat.find_directory_entry_by_lfn(
+                &mut data.block_cache,
+                &data.open_dirs[directory_idx],
+                name,
+            ),
+        };
+
+        let dir_entry = match dir_entry {
+            Ok(entry) => {
+                // we are opening an existing file
+                entry
+            }
+            Err(_)
+                if (mode == Mode::ReadWriteCreate)
+                    | (mode == Mode::ReadWriteCreateOrTruncate)
+                    | (mode == Mode::ReadWriteCreateOrAppend) =>
+            {
+                // We are opening a non-existant file and we cannot do that with LFNs
+                return Err(Error::NotFound);
+            }
+            _ => {
+                // We are opening a non-existant file, and that's not OK.
+                return Err(Error::NotFound);
+            }
+        };
+
+        // Check if it's open already
+        if data.file_is_open(volume_info.raw_volume, &dir_entry) {
+            return Err(Error::FileAlreadyOpen);
+        }
+
+        let mode = solve_mode_variant(mode, true);
+
+        match mode {
+            Mode::ReadWriteCreate => {
+                return Err(Error::FileAlreadyExists);
+            }
+            _ => {
+                if dir_entry.attributes.is_read_only() && mode != Mode::ReadOnly {
+                    return Err(Error::ReadOnly);
+                }
+
+                if dir_entry.attributes.is_directory() {
+                    return Err(Error::OpenedDirAsFile);
+                }
+
+                // Check it's not already open
+                if data.file_is_open(volume_id, &dir_entry) {
+                    return Err(Error::FileAlreadyOpen);
+                }
+
+                let mode = solve_mode_variant(mode, true);
+                let raw_file = RawFile(data.id_generator.generate());
+
+                let file = match mode {
+                    Mode::ReadOnly => FileInfo {
+                        raw_file,
+                        raw_volume: volume_id,
+                        current_cluster: (0, dir_entry.cluster),
+                        current_offset: 0,
+                        mode,
+                        entry: dir_entry,
+                        dirty: false,
+                    },
+                    Mode::ReadWriteAppend => {
+                        let mut file = FileInfo {
+                            raw_file,
+                            raw_volume: volume_id,
+                            current_cluster: (0, dir_entry.cluster),
+                            current_offset: 0,
+                            mode,
+                            entry: dir_entry,
+                            dirty: false,
+                        };
+                        // seek_from_end with 0 can't fail
+                        file.seek_from_end(0).ok();
+                        file
+                    }
+                    Mode::ReadWriteTruncate => {
+                        let mut file = FileInfo {
+                            raw_file,
+                            raw_volume: volume_id,
+                            current_cluster: (0, dir_entry.cluster),
+                            current_offset: 0,
+                            mode,
+                            entry: dir_entry,
+                            dirty: false,
+                        };
+                        match &mut data.open_volumes[volume_idx].volume_type {
+                            VolumeType::Fat(fat) => fat.truncate_cluster_chain(
+                                &mut data.block_cache,
+                                file.entry.cluster,
+                            )?,
+                        };
+                        file.update_length(0);
+                        match &data.open_volumes[volume_idx].volume_type {
+                            VolumeType::Fat(fat) => {
+                                file.entry.mtime = self.time_source.get_timestamp();
+                                fat.write_entry_to_disk(&mut data.block_cache, &file.entry)?;
+                            }
+                        };
+
+                        file
+                    }
+                    _ => return Err(Error::Unsupported),
+                };
+
+                // Remember this open file - can't be full as we checked already
+                unsafe {
+                    data.open_files.push_unchecked(file);
+                }
+
+                Ok(raw_file)
+            }
+        }
+    }
+
     /// Delete a closed file or empty directory with the given filename, if it exists.
     pub fn delete_entry_in_dir<N>(
         &self,

--- a/tests/directories.rs
+++ b/tests/directories.rs
@@ -117,6 +117,7 @@ fn fat16_root_directory_listing() {
     volume_mgr
         .iterate_dir_lfn(root_dir, &mut lfn_buffer, |d, opt_lfn| {
             listing.push((d.clone(), opt_lfn.map(String::from)));
+            embedded_sdmmc::Continue::Yes
         })
         .expect("iterate directory");
 
@@ -193,6 +194,7 @@ fn fat16_sub_directory_listing() {
             }
             count += 1;
             listing.push(d.clone());
+            embedded_sdmmc::Continue::Yes
         })
         .expect("iterate directory");
 
@@ -315,6 +317,7 @@ fn fat32_root_directory_listing() {
     volume_mgr
         .iterate_dir_lfn(root_dir, &mut lfn_buffer, |d, opt_lfn| {
             listing.push((d.clone(), opt_lfn.map(String::from)));
+            embedded_sdmmc::Continue::Yes
         })
         .expect("iterate directory");
 
@@ -521,6 +524,7 @@ fn make_directory() {
             } else {
                 panic!("Unexpected item in new dir");
             }
+            embedded_sdmmc::Continue::Yes
         })
         .unwrap();
     assert!(has_this);
@@ -565,6 +569,7 @@ fn make_directory() {
             } else {
                 panic!("Unexpected item in new dir");
             }
+            embedded_sdmmc::Continue::Yes
         })
         .unwrap();
     assert!(has_this);

--- a/tests/open_files.rs
+++ b/tests/open_files.rs
@@ -92,6 +92,40 @@ fn open_files() {
 }
 
 #[test]
+fn open_lfn() {
+    let time_source = utils::make_time_source();
+    let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
+    let volume_mgr: VolumeManager<utils::RamDisk<Vec<u8>>, utils::TestTimeSource, 4, 2, 1> =
+        VolumeManager::new_with_limits(disk, time_source, 0xAA00_0000);
+    let volume = volume_mgr.open_volume(VolumeIdx(1)).expect("open volume");
+    let root_dir = volume.open_root_dir().expect("open root dir");
+    let _f = root_dir
+        .open_long_name_file_in_dir("Copy of Readme.txt", Mode::ReadOnly)
+        .expect("open file");
+
+    assert!(matches!(
+        root_dir.open_long_name_file_in_dir("Copy of Readme.tx", Mode::ReadOnly),
+        Err(embedded_sdmmc::Error::NotFound)
+    ));
+    assert!(matches!(
+        root_dir.open_long_name_file_in_dir("opy of Readme.txt", Mode::ReadOnly),
+        Err(embedded_sdmmc::Error::NotFound)
+    ));
+    assert!(matches!(
+        root_dir.open_long_name_file_in_dir("Copyof Readme.txt", Mode::ReadOnly),
+        Err(embedded_sdmmc::Error::NotFound)
+    ));
+    assert!(matches!(
+        root_dir.open_long_name_file_in_dir("Copy_of Readme.txt", Mode::ReadOnly),
+        Err(embedded_sdmmc::Error::NotFound)
+    ));
+    assert!(matches!(
+        root_dir.open_long_name_file_in_dir("Nonsense", Mode::ReadOnly),
+        Err(embedded_sdmmc::Error::NotFound)
+    ));
+}
+
+#[test]
 fn open_non_raw() {
     let time_source = utils::make_time_source();
     let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();


### PR DESCRIPTION
Adds a new API which lets you open files by their long file name.

Does not (currently) let you open directories in this manner, nor does it let you create files with a long file name.

Builds on #216 