### PR TITLE
Downgraded one log level from warn! to trace! ...

### DIFF
--- a/src/sdcard/spi.rs
+++ b/src/sdcard/spi.rs
@@ -401,7 +401,7 @@ where
                     }
                     Ok(_r) => {
                         // Try again
-                        crate::warn!("Got response: {:x}, trying again..", _r);
+                        crate::trace!("Got response: {:x}, trying again..", _r);
                     }
                 }
 


### PR DESCRIPTION
... when other-than expected byte returned from CMD0 initialization.

I am but one user of this crate, however using my particular SD Card + reader, the current logging scheme results in a flurry of yellow "warning"-level log messages 100% of the time during project initialization for what is, as best as I can tell, a completely expected scenario.

Given that this initialization occurs in a finite retry loop which return an `Err` once the retries are exceeded, might it make sense to downgrade the log level of this particular message?

