### PR TITLE
Fix `has_open_handles()` boolean logic

### DIFF
--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -1236,7 +1236,7 @@ where
     /// Check if any files or folders are open.
     pub fn has_open_handles(&self) -> bool {
         let data = self.data.borrow();
-        !(data.open_dirs.is_empty() || data.open_files.is_empty())
+        !(data.open_dirs.is_empty() && data.open_files.is_empty())
     }
 
     /// Consume self and return BlockDevice and TimeSource

--- a/tests/volume.rs
+++ b/tests/volume.rs
@@ -108,6 +108,37 @@ fn close_volume_too_early() {
     ));
 }
 
+#[test]
+fn has_open_handles_reports_open_dirs() {
+    let time_source = utils::make_time_source();
+    let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+
+    // No handles open
+    assert!(!volume_mgr.has_open_handles());
+
+    let volume = volume_mgr
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
+        .expect("open volume 0");
+    let root_dir = volume_mgr.open_root_dir(volume).expect("open root dir");
+
+    // A directory is open but no files — should report true
+    assert!(volume_mgr.has_open_handles());
+
+    volume_mgr.close_dir(root_dir).unwrap();
+
+    // Nothing open again
+    assert!(!volume_mgr.has_open_handles());
+
+    let root_dir = volume_mgr.open_root_dir(volume).expect("open root dir");
+    let _file = volume_mgr
+        .open_file_in_dir(root_dir, "README.TXT", embedded_sdmmc::Mode::ReadOnly)
+        .expect("open file");
+
+    // Both a dir and a file are open
+    assert!(volume_mgr.has_open_handles());
+}
+
 // ****************************************************************************
 //
 // End Of File


### PR DESCRIPTION
`has_open_handles()` currently uses:

```
!(open_dirs.is_empty() || open_files.is_empty())
```

By De Morgan's law this is `!dirs_empty && !files_empty`, so it only returns
`true` when both collections are non-empty. If you have an open directory
but no open files (or vice-versa), it incorrectly returns `false`.

Fixed by changing `||` to `&&`:

```
!(open_dirs.is_empty() && open_files.is_empty())
```
I've included a regression test.

