### PR TITLE
Fix FAT32 directory iteration not stopping on ControlFlow::Break

### DIFF
--- a/src/fat/volume.rs
+++ b/src/fat/volume.rs
@@ -761,7 +761,7 @@ impl FatVolume {
             ClusterId::ROOT_DIR => Some(fat32_info.first_root_dir_cluster),
             _ => Some(dir_info.cluster),
         };
-        while let Some(cluster) = current_cluster {
+        'outer: while let Some(cluster) = current_cluster {
             let start_block_idx = self.cluster_to_block(cluster);
             for block_idx in start_block_idx.range(BlockCount(u32::from(self.blocks_per_cluster))) {
                 trace!("Reading FAT");
@@ -770,14 +770,14 @@ impl FatVolume {
                     let dir_entry = OnDiskDirEntry::new(dir_entry_bytes);
                     if dir_entry.is_end() {
                         // Can quit early
-                        break;
+                        break 'outer;
                     } else if dir_entry.is_valid() {
                         // Safe, since Block::LEN always fits on a u32
                         let start = (i * OnDiskDirEntry::LEN) as u32;
                         let entry = dir_entry.get_entry(FatType::Fat32, block_idx, start);
                         if let ControlFlow::Break(_) = func(&entry, &dir_entry) {
                             // Can quit early
-                            break;
+                            break 'outer;
                         }
                     }
                 }

--- a/tests/directories.rs
+++ b/tests/directories.rs
@@ -644,6 +644,61 @@ fn delete_directory() {
     ));
 }
 
+/// Verify that `iterate_dir` on a FAT32 volume stops calling the callback
+/// after it returns `ControlFlow::Break`, even when directory entries span
+/// multiple 512-byte blocks (i.e. more than 16 on-disk entries).
+#[test]
+fn fat32_iterate_dir_break_stops_immediately() {
+    let time_source = utils::make_time_source();
+    let disk = utils::make_block_device(utils::DISK_SOURCE).unwrap();
+    let volume_mgr = embedded_sdmmc::VolumeManager::new(disk, time_source);
+
+    let fat32_volume = volume_mgr
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(1))
+        .expect("open volume 1");
+    let root_dir = volume_mgr
+        .open_root_dir(fat32_volume)
+        .expect("open root dir");
+
+    // Create a fresh subdirectory to work in.
+    let dir_name = ShortFileName::create_from_str("BREAKDIR").unwrap();
+    volume_mgr
+        .make_dir_in_dir(root_dir, &dir_name)
+        .expect("make BREAKDIR");
+    let test_dir = volume_mgr
+        .open_dir(root_dir, &dir_name)
+        .expect("open BREAKDIR");
+
+    // The subdirectory already has "." and ".." (2 entries). Create 15 files
+    // so we have 17 on-disk entries total, which exceeds one 512-byte block
+    // (512 / 32 = 16 entries per block).
+    for i in 0..15 {
+        let name = format!("F{:07}.TXT", i);
+        let sfn = ShortFileName::create_from_str(&name).unwrap();
+        let f = volume_mgr
+            .open_file_in_dir(test_dir, &sfn, Mode::ReadWriteCreate)
+            .expect("create file");
+        volume_mgr.close_file(f).expect("close file");
+    }
+
+    // Now iterate with a callback that breaks immediately.
+    let mut call_count = 0u32;
+    volume_mgr
+        .iterate_dir(test_dir, |_entry| {
+            call_count += 1;
+            ControlFlow::Break(())
+        })
+        .expect("iterate dir");
+
+    assert_eq!(
+        call_count, 1,
+        "callback was invoked {call_count} times, expected exactly 1 after Break"
+    );
+
+    volume_mgr.close_dir(test_dir).expect("close BREAKDIR");
+    volume_mgr.close_dir(root_dir).expect("close root");
+}
+
 // ****************************************************************************
 //
 // End Of File


### PR DESCRIPTION
`iterate_fat32` use a plain `break` when the callback returns `ControlFlow::Break(())` or when `is_end()` is hit. This only exits the innermost loop and the iteration continues with the next block and next cluster calling the callback with more entries. I believe in practice this still returns the correct result, but the callback is invoked more times than it
should be so unnecessary block I/O is performed.

The equivalent `iterate_fat16` uses `break 'outer` to exit all three nested loops.

Fixed by adding an `'outer:` label to the `while` loop and changing both
`break` statements to `break 'outer`, matching `iterate_fat16`.

The pr includes a regression test to validate this.
