### PR TITLE
Fix lifetime of returned dierctories and files

### DIFF
--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -120,7 +120,7 @@ where
     pub fn open_dir<N>(
         &self,
         name: N,
-    ) -> Result<Directory<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>>
+    ) -> Result<Directory<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>>
     where
         N: ToShortFileName,
     {
@@ -196,7 +196,7 @@ where
         &self,
         name: N,
         mode: crate::Mode,
-    ) -> Result<crate::File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, crate::Error<D::Error>>
+    ) -> Result<crate::File<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, crate::Error<D::Error>>
     where
         N: super::ToShortFileName,
     {
@@ -214,7 +214,7 @@ where
         &self,
         name: &str,
         mode: crate::Mode,
-    ) -> Result<crate::File<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, crate::Error<D::Error>>
+    ) -> Result<crate::File<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, crate::Error<D::Error>>
     {
         let f = self
             .volume_mgr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ where
     /// use `open_file_in_dir`.
     pub fn open_root_dir(
         &self,
-    ) -> Result<crate::Directory<'_, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>> {
+    ) -> Result<crate::Directory<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>> {
         let d = self.volume_mgr.open_root_dir(self.raw_volume)?;
         Ok(d.to_directory(self.volume_mgr))
     }


### PR DESCRIPTION
This Pr fixes the lifetime of `open_dir`, `open_root_dir` and `open_file_in_dir` by using the lifetime `'a` of `Directory<'a>` instead of relying on the temporary lifetime of `&self`.

The change is backward compatible.

Note that we could simplify the return type by simply using `Self`. I am not sure if this adheres to the code style of this project.