### PR TITLE
IUse Self where it makes the return type easier to read/parse

### DIFF
--- a/src/blockdevice.rs
+++ b/src/blockdevice.rs
@@ -101,7 +101,7 @@ where
     D: BlockDevice,
 {
     /// Create a new block cache
-    pub fn new(block_device: D) -> BlockCache<D> {
+    pub fn new(block_device: D) -> Self {
         BlockCache {
             block_device,
             block: [Block::new()],

--- a/src/filesystem/directory.rs
+++ b/src/filesystem/directory.rs
@@ -104,7 +104,7 @@ where
     pub fn new(
         raw_directory: RawDirectory,
         volume_mgr: &'a VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
-    ) -> Directory<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES> {
+    ) -> Self {
         Directory {
             raw_directory,
             volume_mgr,
@@ -117,10 +117,7 @@ where
     ///
     /// See [`VolumeManager::open_dir`] for details, except the directory
     /// given is this directory.
-    pub fn open_dir<N>(
-        &self,
-        name: N,
-    ) -> Result<Directory<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>, Error<D::Error>>
+    pub fn open_dir<N>(&self, name: N) -> Result<Self, Error<D::Error>>
     where
         N: ToShortFileName,
     {

--- a/src/filesystem/filename.rs
+++ b/src/filesystem/filename.rs
@@ -237,7 +237,7 @@ pub struct LfnBuffer<'a> {
 
 impl<'a> LfnBuffer<'a> {
     /// Create a new, empty, LFN Buffer using the given mutable slice as its storage.
-    pub fn new(storage: &'a mut [u8]) -> LfnBuffer<'a> {
+    pub fn new(storage: &'a mut [u8]) -> Self {
         // Because `free` is a `u16`, we keep at most `u16::MAX` bytes of the buffer.
         // It is enough to hold all LFN because a LFN has at most 255 characters.
         // A UTF-8 character takes at most 3 bytes.

--- a/src/filesystem/files.rs
+++ b/src/filesystem/files.rs
@@ -68,7 +68,7 @@ where
     pub fn new(
         raw_file: RawFile,
         volume_mgr: &'a VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
-    ) -> File<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES> {
+    ) -> Self {
         File {
             raw_file,
             volume_mgr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ where
     pub fn new(
         raw_volume: RawVolume,
         volume_mgr: &'a VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES>,
-    ) -> Volume<'a, D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES> {
+    ) -> Self {
         Volume {
             raw_volume,
             volume_mgr,

--- a/src/sdcard/spi.rs
+++ b/src/sdcard/spi.rs
@@ -45,7 +45,7 @@ where
     /// deferred until a method is called on the object.
     ///
     /// Uses the default options.
-    pub fn new(spi: SPI, delayer: DELAYER) -> SdCard<SPI, DELAYER> {
+    pub fn new(spi: SPI, delayer: DELAYER) -> Self {
         Self::new_with_options(spi, delayer, AcquireOpts::default())
     }
 
@@ -56,11 +56,7 @@ where
     ///
     /// The card will not be initialised at this time. Initialisation is
     /// deferred until a method is called on the object.
-    pub fn new_with_options(
-        spi: SPI,
-        delayer: DELAYER,
-        options: AcquireOpts,
-    ) -> SdCard<SPI, DELAYER> {
+    pub fn new_with_options(spi: SPI, delayer: DELAYER, options: AcquireOpts) -> Self {
         SdCard {
             inner: RefCell::new(SdCardInner {
                 spi,

--- a/src/volume_mgr.rs
+++ b/src/volume_mgr.rs
@@ -53,7 +53,7 @@ where
     /// This creates a `VolumeManager` with default values
     /// MAX_DIRS = 4, MAX_FILES = 4, MAX_VOLUMES = 1. Call `VolumeManager::new_with_limits(block_device, time_source)`
     /// if you need different limits.
-    pub fn new(block_device: D, time_source: T) -> VolumeManager<D, T, 4, 4, 1> {
+    pub fn new(block_device: D, time_source: T) -> Self {
         // Pick a random starting point for the IDs that's not zero, because
         // zero doesn't stand out in the logs.
         Self::new_with_limits(block_device, time_source, 5000)
@@ -73,11 +73,7 @@ where
     /// You can also give an offset for all the IDs this volume manager
     /// generates, which might help you find the IDs in your logs when
     /// debugging.
-    pub fn new_with_limits(
-        block_device: D,
-        time_source: T,
-        id_offset: u32,
-    ) -> VolumeManager<D, T, MAX_DIRS, MAX_FILES, MAX_VOLUMES> {
+    pub fn new_with_limits(block_device: D, time_source: T, id_offset: u32) -> Self {
         debug!("Creating new embedded-sdmmc::VolumeManager");
         VolumeManager {
             time_source,


### PR DESCRIPTION
As [suggested here](https://github.com/rust-embedded-community/embedded-sdmmc-rs/pull/235#issuecomment-4088389942) I am opening this PR to simplify the return type of some function using `Self`. This makes it easier to parse the type and to understand what is returned.

Note that there exists a Clippy rule `use_self`, however it forces using `Self` everywhere where applicable.